### PR TITLE
ci: bump Go directive to 1.25.9 to absorb stdlib vuln fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cordum-io/cap/v2
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary

The CI workflow uses `go-version-file: 'go.mod'` (`.github/workflows/ci.yml:21`),
so the Go runner version is whatever the module declares. `go.mod` was pinned
at `go 1.25.8`.

Go **1.25.9** (2026-03-19) shipped fixes for:

- `GO-2026-4865` — `html/template` JsBraceDepth context-tracking bugs (XSS)
- 3 stdlib vulns in the `crypto/tls` / `net/http` families

`govulncheck` in the **Go SDK** CI job has been failing on these on every
run since 1.25.9 landed — including on Node-only PRs like #39 that don't
touch any Go source. See the trailing error on PR #39's Go SDK check:

> Vulnerability #4: GO-2026-4865 — Fixed in: html/template@go1.25.9

Bumping the `go.mod` directive to `1.25.9` resolves all four stdlib findings
without a runtime-behavior change. The workflow itself isn't touched.

## Scope

One-line diff:

```diff
 module github.com/cordum-io/cap/v2

-go 1.25.8
+go 1.25.9
```

## Test plan

- [ ] CI on this PR is green (specifically the Go SDK job's `govulncheck` step).
- [ ] No ripple in Node SDK / Python SDK / Python Guard SDK / CodeQL checks.
- [ ] Post-merge: re-run the Node-only dependabot PRs (if any land again) — Go SDK should no longer red-stop them.