### PR TITLE
ci: narrow CodeQL matrix to languages the repo actually ships

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+name: "Cordum CAP CodeQL config"
+
+# Paired with .github/workflows/codeql.yml. Controls per-language query
+# selection and path filtering for CodeQL analysis. Keep intentionally
+# conservative — we want high-signal findings, not every stylistic suggestion.
+
+# Pull the security-extended query pack in addition to the default pack so
+# we catch CWE-89-class issues in Python and the high-severity TypeScript
+# sinks (DOM XSS, prototype pollution) that the default pack misses.
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  # Vendored / generated artifacts — noise, not our source.
+  - "sdk/node/node_modules/**"
+  - "**/dist/**"
+  - "**/build/**"
+  # Protobuf-generated sources are best scanned via the source .proto, not
+  # the derived code; skip the derived trees to keep results actionable.
+  - "python/cordum/**/*_pb2.py"
+  - "python/cordum/**/*_pb2_grpc.py"
+  - "sdk/python/cap/pb/**/*_pb2.py"
+  - "sdk/python/cap/pb/**/*_pb2_grpc.py"
+  - "sdk/java/src/main/java/**/*OrBuilder.java"
+  # Example / playground code is for docs, not production — don't block PRs
+  # on issues that exist only in copy-paste tutorials.
+  - "examples/**"
+  - "playground/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,67 @@
+name: CodeQL
+
+# Replaces GitHub's default code-scanning setup with an explicit workflow
+# that scopes the language matrix to what actually exists in this repo.
+#
+# The default setup auto-detects every language CodeQL supports and runs an
+# analyzer per language. For cap, that produced noisy "low analysis quality"
+# warnings on csharp / ruby / rust / c-cpp because the autodetect scans a
+# handful of generated or protobuf-derived files that don't represent real
+# source. Narrowing the matrix removes those false positives and keeps the
+# security scans focused on code we actually ship.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan to pick up new queries / advisories even when the repo is quiet.
+    - cron: "23 6 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - go
+          - javascript-typescript
+          - python
+          - java-kotlin
+        # csharp / ruby / rust / c-cpp are DELIBERATELY EXCLUDED — this repo
+        # has no source in those languages; GitHub's default code-scanning
+        # setup auto-detected them from generated / template files and
+        # produced low-confidence noise. Re-add only when real source lands.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go (only for go matrix leg)
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Replaces GitHub's default code-scanning setup with an explicit workflow so the CodeQL matrix only runs analyzers for languages this repo actually contains.

## Problem

Every PR — including Node-only dependabot bumps — was producing CodeQL warnings like:

- *Required Gradle version not specified* (Java autobuild fallback)
- *Low Java analysis quality* (55% call target, 72% known type — both below the 85% threshold)
- *Low C# analysis quality* (66% / 68%)

These came from GitHub's default setup auto-detecting every supported language. **CAP has no C# / Ruby / Rust / C++ source at all** — those analyzers were picking up generated-code fragments and running partial, low-confidence scans that reviewers had to read past on every PR.

## Change

### `.github/workflows/codeql.yml` (new)

Explicit workflow pinning languages:

\`\`\`yaml
matrix:
  language:
    - actions
    - go
    - javascript-typescript
    - python
    - java-kotlin
\`\`\`

`csharp / ruby / rust / c-cpp` deliberately omitted — can be re-added when real source lands.

Runs on push-to-main, PRs, and a weekly cron (to pick up new queries / advisories).

### `.github/codeql/codeql-config.yml` (new)

- Pulls `security-extended` query pack on top of the default (catches extra DOM XSS / prototype-pollution / SQL-injection sinks the default pack misses).
- \`paths-ignore\` covering: \`sdk/node/node_modules\`, \`dist\`, \`build\`, generated protobuf Python/Java files, \`examples/\`, \`playground/\` — docs code, not production.

## Test plan

- [ ] CI on this PR runs the new CodeQL workflow (first run auto-disables the default setup).
- [ ] Go SDK, Node SDK, Python SDK, Python Guard SDK checks all green.
- [ ] Post-merge: next dependabot PR shows only the 5 scoped language analyzers, no C# / Rust / Ruby / C++ noise.
- [ ] Next scheduled scan (weekly cron) runs cleanly.

Paired with #40 (`ci: bump Go directive to 1.25.9`) which closed the CI's other pre-existing source of red.