### PR TITLE
ci(codeql): switch java-kotlin to build-mode: none

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,21 @@ name: CodeQL
 # handful of generated or protobuf-derived files that don't represent real
 # source. Narrowing the matrix removes those false positives and keeps the
 # security scans focused on code we actually ship.
+#
+# Build modes per language:
+#   * actions / javascript-typescript / python  → build-mode: none (source-only)
+#   * go                                        → autobuild (go-version pinned
+#                                                 via go.mod so govulncheck
+#                                                 sees the current toolchain)
+#   * java-kotlin                               → build-mode: none — sdk/java
+#                                                 has no Gradle wrapper, and
+#                                                 CodeQL's java autobuild needs
+#                                                 one. Source-only analysis
+#                                                 still catches high-severity
+#                                                 sinks in hand-written code;
+#                                                 the generated protobuf
+#                                                 classes are filtered by
+#                                                 codeql-config.yml paths-ignore.
 
 on:
   push:
@@ -31,12 +46,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - actions
-          - go
-          - javascript-typescript
-          - python
-          - java-kotlin
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: java-kotlin
+            build-mode: none
         # csharp / ruby / rust / c-cpp are DELIBERATELY EXCLUDED — this repo
         # has no source in those languages; GitHub's default code-scanning
         # setup auto-detected them from generated / template files and
@@ -56,9 +76,11 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Autobuild
+      - name: Autobuild (go only)
+        if: matrix.build-mode == 'autobuild'
         uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary

Fixes the Java CodeQL job that broke on #41 because \`sdk/java\` has no Gradle wrapper, so CodeQL's autobuild can't build the Java source:

\`\`\`
ERROR: Could not detect a suitable build command for the source checkout.
We were unable to automatically build your code. Please replace the call
to the autobuild action with your custom build steps.
\`\`\`

## Change

- Rewrite the matrix from a flat language list to an \`include\` list that carries \`build-mode\` per language:
  - \`actions\` / \`javascript-typescript\` / \`python\` / \`java-kotlin\` → \`build-mode: none\` (source-only analysis)
  - \`go\` → \`autobuild\` (unchanged — go autobuild has always worked)
- Autobuild step is now conditional (\`if: matrix.build-mode == 'autobuild'\`) so only the go leg runs it.

## Why source-only for java-kotlin

\`sdk/java\` is mostly protobuf-generated classes plus a thin API layer. We don't ship a Gradle wrapper because this repo doesn't build Java in CI (publishing to Maven Central is a separate, manual release path). CodeQL source-only mode still catches high-severity sinks (injection, XSS, hardcoded secrets) in the hand-written API layer — generated protobuf classes are already excluded via \`codeql-config.yml\` paths-ignore.

Alternative considered: add a Gradle wrapper to \`sdk/java\`. Rejected as scope creep — the SDK is not actively built in CI and adding infrastructure to satisfy CodeQL alone is the tail wagging the dog.

## Test plan

- [ ] CI on this PR: \`Analyze (java-kotlin)\` turns green.
- [ ] Other matrix legs (actions / go / js / python) unaffected.
- [ ] Post-merge: next PR to main shows Java CodeQL green.

Paired with #40 + #41 which landed earlier this session.