### PR TITLE
ci: pin actions to commit SHAs + add explicit permissions to wiki-sync

### DIFF
--- a/.github/workflows/publish-python-guard.yml
+++ b/.github/workflows/publish-python-guard.yml
@@ -97,7 +97,7 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: sdk/python-guard/dist
           skip-existing: true

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -128,7 +128,7 @@ jobs:
           "$PYTHON_BIN" -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: sdk/python/dist
           skip-existing: true

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -8,12 +8,25 @@ on:
       - 'wiki/**'
   workflow_dispatch: # <--- THIS LINE ADDS THE BUTTON
 
+permissions:
+  # Read-only is enough: actions/checkout needs contents:read, and the
+  # wiki push uses its own WIKI_TOKEN PAT (scoped to the wiki repo),
+  # not the default GITHUB_TOKEN. Explicit block closes the
+  # `actions/missing-workflow-permissions` CodeQL alert.
+  contents: read
+
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+      # SHA pins close the `actions/unpinned-tag` CodeQL alert class.
+      # Floating tags (@v4, @release/v1) are mutable and a maintainer
+      # takeover or publish-hijack would silently replace action code on
+      # next workflow run.
+      # Update cadence: bump these SHAs when a known-good release lands;
+      # the workflow doesn't auto-upgrade, which is the point.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.7
+      - uses: Andrew-Chen-Wang/github-wiki-action@50650fccf3a10f741995523cf9708c53cec8912a # v4
         with:
           token: ${{ secrets.WIKI_TOKEN }}
           path: wiki


### PR DESCRIPTION
## Summary

Closes **4 CodeQL advisories** surfaced by the \`security-extended\` query pack after #41 + #42 activated the explicit CodeQL workflow. All are supply-chain / workflow-hygiene findings, no runtime defects.

## Fixes

### \`actions/unpinned-tag\` × 3

Replaced floating tags with commit SHAs so a maintainer takeover or publish-hijack of any of these actions can no longer silently replace action code on the next workflow run.

| File:Line | Before | After |
|---|---|---|
| \`publish-python.yml:131\` | \`pypa/gh-action-pypi-publish@release/v1\` | \`@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1\` |
| \`publish-python-guard.yml:100\` | \`pypa/gh-action-pypi-publish@release/v1\` | same SHA |
| \`wiki-sync.yml:16\` | \`Andrew-Chen-Wang/github-wiki-action@v4\` | \`@50650fccf3a10f741995523cf9708c53cec8912a # v4\` |

Also pinned \`actions/checkout@v4\` → \`@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.7\` in \`wiki-sync.yml\` while touching the file (defence-in-depth; CodeQL didn't flag GitHub-org actions but pinning all third-party + first-party to SHAs is the standard posture).

### \`actions/missing-workflow-permissions\` × 1

\`wiki-sync.yml\` had no top-level \`permissions:\` block, so it inherited the default GITHUB_TOKEN scope. Added:

\`\`\`yaml
permissions:
  contents: read
\`\`\`

Why read-only suffices: \`actions/checkout\` needs \`contents: read\`, and the wiki push uses the \`WIKI_TOKEN\` PAT (scoped to the wiki repo), not the default GITHUB_TOKEN.

## Maintenance model

Pin cadence: bump these SHAs only when a known-good release lands and someone reviews the diff. The workflow won't auto-upgrade — that's the point. Pin-update PRs should carry release notes + diff summary of what changed in the action between the old and new SHA.

## Test plan

- [ ] Explicit CodeQL workflow runs on this PR and reports all 5 language legs green.
- [ ] 4 CodeQL alerts close automatically when the scan finishes scanning main post-merge.
- [ ] Next PyPI release (v2.9.3 or later) still publishes correctly through the pinned \`gh-action-pypi-publish\`.
- [ ] Next wiki push still syncs via the pinned \`github-wiki-action\`.

Paired with #40 (Go toolchain bump), #41 (CodeQL narrow), #42 (Java build-mode: none) — the CI-hygiene sweep concludes with this PR.