### PR TITLE
feat(sdk-go): add agent.go Register/Lookup/SetScope wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Entries are grouped by SDK release tag. Wire schema changes (protobuf field addi
 
 ## Unreleased — Protocol Hardening
 
+- **Go SDK:** Added `sdk/go/agent.go` — `AgentClient` with `Register(ctx, AgentSpec) (id, error)`, `Lookup(ctx, name, tenant) (*AgentIdentity, error)`, and `SetScope(ctx, AgentScopeUpdate) error` wrapping the Cordum control-plane endpoints `POST /api/v1/agents`, `GET /api/v1/agents`, `PUT /api/v1/agents/{id}`. Bearer-token-supplants-X-API-Key auth, configurable tenant header, idempotency-key support on SetScope. Source-of-truth wrappers so service bootstraps (cordum-llm-chat phase 3, future services) stop rolling their own MCP-fallback registration paths.
+- **Go SDK:** `Register` payload deliberately omits `preapproved_mutating_tools` per the gateway's `registerAgentArgs`/`updateAgentRequest` split — preapproved mutations are a post-registration `SetScope` privilege, never a create-time grant.
+- **Go SDK:** `SetScope` always sends `preapproved_mutating_tools` (including empty `[]`) so operators have a deterministic revoke path for chat-assistant-style agents.
 - **[WIRE]** Added `ErrorCode` enum and `error_code_enum` field to `JobResult` for structured error classification.
 - **[WIRE]** Enhanced `SystemAlert` with `AlertSeverity` enum and structured fields (`severity`, `source_component`, `details`, `trace_id`).
 - **[WIRE]** Added `Handshake` message for capability negotiation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Entries are grouped by SDK release tag. Wire schema changes (protobuf field addi
 
 ## Unreleased — Protocol Hardening
 
+- **Docs:** Added [`docs/agent-registration.md`](docs/agent-registration.md) — surface description of `AgentClient.Register/Lookup/SetScope`, the create-time vs `SetScope` preapproval split, and the canonical real-world consumer (Cordum's own LLM chat copilot). Cross-links to the bi-directional [governance senior review](https://github.com/cordum-io/cordum/blob/main/docs/llmchat/governance-review.md) in the cordum repo so the dogfooding evidence is reachable from both sides.
 - **Go SDK:** Added `sdk/go/agent.go` — `AgentClient` with `Register(ctx, AgentSpec) (id, error)`, `Lookup(ctx, name, tenant) (*AgentIdentity, error)`, and `SetScope(ctx, AgentScopeUpdate) error` wrapping the Cordum control-plane endpoints `POST /api/v1/agents`, `GET /api/v1/agents`, `PUT /api/v1/agents/{id}`. Bearer-token-supplants-X-API-Key auth, configurable tenant header, idempotency-key support on SetScope. Source-of-truth wrappers so service bootstraps (cordum-llm-chat phase 3, future services) stop rolling their own MCP-fallback registration paths.
 - **Go SDK:** `Register` payload deliberately omits `preapproved_mutating_tools` per the gateway's `registerAgentArgs`/`updateAgentRequest` split — preapproved mutations are a post-registration `SetScope` privilege, never a create-time grant.
 - **Go SDK:** `SetScope` always sends `preapproved_mutating_tools` (including empty `[]`) so operators have a deterministic revoke path for chat-assistant-style agents.

--- a/docs/agent-registration.md
+++ b/docs/agent-registration.md
@@ -1,0 +1,52 @@
+# Agent Registration via CAP
+
+This page documents the CAP `AgentClient` API for registering, looking up, and scoping AI agent identities against a Cordum control plane. It is the source-of-truth wrapper that service bootstraps depend on for idempotent registration, scope updates, and deterministic preapproval revocation.
+
+## Surface
+
+`sdk/go/agent.go` (Go reference SDK) exposes:
+
+```go
+type AgentClient struct {
+    BaseURL    string // e.g. https://gateway.example.com
+    APIKey     string // service-account X-API-Key (used for register/lookup/scope only)
+    Tenant     string // tenant header value
+    HTTPClient *http.Client
+}
+
+func (c *AgentClient) Register(ctx context.Context, spec AgentSpec) (id string, err error)
+func (c *AgentClient) Lookup(ctx context.Context, name, tenant string) (*AgentIdentity, error)
+func (c *AgentClient) SetScope(ctx context.Context, update AgentScopeUpdate) error
+```
+
+The wrappers hit the Cordum control-plane REST endpoints directly:
+
+| Operation | HTTP                                  | Notes                                                                                  |
+| --------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
+| Register  | `POST /api/v1/agents`                 | `AgentSpec` deliberately omits `preapproved_mutating_tools` — see [Scope rules](#scope-rules). |
+| Lookup    | `GET /api/v1/agents?name=...`         | Single-result idempotency check; multiple matches return an error.                     |
+| SetScope  | `PUT /api/v1/agents/{id}`             | Always sends `preapproved_mutating_tools` (including empty `[]`) for deterministic revoke. Supports an `Idempotency-Key` header. |
+
+## Scope rules
+
+- **Preapproval is post-registration.** `Register` never grants preapproved mutating tools; the create-time payload is intentionally narrow. Operators grant preapproval through `SetScope` after a separate review of the tool list. This split mirrors `registerAgentArgs` vs. `updateAgentRequest` in the gateway and keeps audit lineage clean.
+- **`SetScope` is the revoke path.** Callers always pass the full `preapproved_mutating_tools` list — including `[]` to revoke everything — so the resulting `AgentIdentity` reflects exactly the operator's intent. Never rely on partial / merge semantics here.
+
+## Real-world consumer: `cordum-llm-chat`
+
+The Cordum LLM chat assistant (the platform's own copilot) is a CAP agent registered with `AgentClient` on first boot. The bootstrap is idempotent and audited like any other Cordum agent.
+
+- **Bootstrap source:** [`core/llmchat/bootstrap.go`](https://github.com/cordum-io/cordum/blob/main/core/llmchat/bootstrap.go) — calls `Lookup("chat-assistant", tenant)` first, falls through to `Register` + `SetScope` on miss; refuses divergent identities.
+- **Wire chain on first boot:**
+  1. `Register(AgentSpec{Name: "chat-assistant", RiskTier: medium, AllowedTools: 14 read + cordum_query_policy + 5 mutators})`.
+  2. `SetScope(AgentScopeUpdate{ID: <new-id>, PreapprovedMutatingTools: ["cordum_submit_job"]})` — exactly one preapproved tool per the chat assistant's epic rail #4 ("widening requires a policy-bundle update by an admin, not a code change").
+- **Audit emission:** the `chat.bootstrap_registered` SIEM action (constant defined in [`core/audit/siem_actions.go`](https://github.com/cordum-io/cordum/blob/main/core/audit/siem_actions.go)) fires on first boot only; restart re-emits **zero** registration events because `Lookup` short-circuits.
+- **Senior-review evidence:** the dogfooding QA — including the scope-first deny ordering, audit chain integrity under chat-driven load, and the per-session delegation token revocation flow — is recorded in [`cordum/docs/llmchat/governance-review.md`](https://github.com/cordum-io/cordum/blob/main/docs/llmchat/governance-review.md). See probe 1 for the round-trip evidence and probe 7 for the scope-filter ordering.
+
+This pattern is the recommended reference for any future Cordum service that needs its own CAP-registered agent identity: never roll your own MCP fallback, never widen preapproval at registration time, always go through `SetScope` for revoke.
+
+## Related
+
+- [Getting started](getting-started.md) — minimal CAP worker.
+- [Reference](reference.md) — full CAP wire contract.
+- [Cordum LLM chat overview](https://github.com/cordum-io/cordum/blob/main/docs/llmchat/overview.md) — where this agent registration runs in production.

--- a/docs/agent-registration.md
+++ b/docs/agent-registration.md
@@ -32,6 +32,31 @@ The wrappers hit the Cordum control-plane REST endpoints directly:
 - **Preapproval is post-registration.** `Register` never grants preapproved mutating tools; the create-time payload is intentionally narrow. Operators grant preapproval through `SetScope` after a separate review of the tool list. This split mirrors `registerAgentArgs` vs. `updateAgentRequest` in the gateway and keeps audit lineage clean.
 - **`SetScope` is the revoke path.** Callers always pass the full `preapproved_mutating_tools` list — including `[]` to revoke everything — so the resulting `AgentIdentity` reflects exactly the operator's intent. Never rely on partial / merge semantics here.
 
+## CLI surface
+
+CAP remains the protocol library and SDK surface; the operator CLI lives in
+the `cordum` repository. For day-2 operations, use:
+
+```bash
+cordumctl agent set-scope <name> \
+  --allowed-tools=tool1,tool2 \
+  --preapproved-mutating-tools=cordum_submit_job \
+  --idempotency-key=<stable-retry-key>
+```
+
+The command wraps `capsdk.AgentClient.SetScope` rather than hand-coding the
+REST request, so CLI behavior stays aligned with the SDK's deterministic
+replace/revoke contract. `--allowed-tools` and
+`--preapproved-mutating-tools` are replace operations; `--add-tool` and
+`--remove-tool` perform a lookup, merge the AllowedTools set, then call
+`SetScope`. `--dry-run` prints the resulting scope update without mutating
+the control plane.
+
+Important split: `AgentSpec` at registration time still cannot grant
+preapproved mutating tools. Register or look up the agent first, then use
+`cordumctl agent set-scope` / `AgentClient.SetScope` to grant, replace, or
+revoke preapproval after review.
+
 ## Real-world consumer: `cordum-llm-chat`
 
 The Cordum LLM chat assistant (the platform's own copilot) is a CAP agent registered with `AgentClient` on first boot. The bootstrap is idempotent and audited like any other Cordum agent.

--- a/sdk/go/agent.go
+++ b/sdk/go/agent.go
@@ -1,0 +1,322 @@
+package capsdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// AgentSpec is the input shape for registering a new agent identity
+// against a Cordum control plane. Only fields the operator wants to
+// pin should be populated; empty strings / nil slices are omitted from
+// the wire payload so the server-side defaults apply.
+//
+// Note: PreapprovedMutatingTools is intentionally NOT a field on
+// AgentSpec. The control plane treats the preapproved set as a
+// post-registration scope adjustment (SetScope) so a malicious or
+// misconfigured registrant cannot grant itself preapproved mutating
+// tools at create time. Operators MUST follow Register with a SetScope
+// call to grant that capability.
+type AgentSpec struct {
+	Name                string   `json:"name"`
+	Description         string   `json:"description,omitempty"`
+	Owner               string   `json:"owner"`
+	Team                string   `json:"team,omitempty"`
+	RiskTier            string   `json:"risk_tier"`
+	AllowedTopics       []string `json:"allowed_topics,omitempty"`
+	AllowedPools        []string `json:"allowed_pools,omitempty"`
+	AllowedTools        []string `json:"allowed_tools,omitempty"`
+	DataClassifications []string `json:"data_classifications,omitempty"`
+}
+
+// AgentIdentity mirrors the canonical agent record returned by the
+// control plane. ID is the server-assigned UUID; CreatedAt / UpdatedAt
+// are RFC3339 strings.
+type AgentIdentity struct {
+	ID                       string   `json:"id"`
+	Name                     string   `json:"name"`
+	Description              string   `json:"description,omitempty"`
+	Owner                    string   `json:"owner"`
+	Team                     string   `json:"team,omitempty"`
+	RiskTier                 string   `json:"risk_tier"`
+	AllowedTopics            []string `json:"allowed_topics,omitempty"`
+	AllowedPools             []string `json:"allowed_pools,omitempty"`
+	AllowedTools             []string `json:"allowed_tools,omitempty"`
+	DataClassifications      []string `json:"data_classifications,omitempty"`
+	PreapprovedMutatingTools []string `json:"preapproved_mutating_tools,omitempty"`
+	Status                   string   `json:"status"`
+	CreatedAt                string   `json:"created_at"`
+	UpdatedAt                string   `json:"updated_at"`
+	LastActive               int64    `json:"last_active,omitempty"`
+}
+
+// AgentScopeUpdate is the input for SetScope. Per-field semantics
+// mirror the control plane: a nil slice means "leave alone"; an empty
+// (non-nil) slice means "clear this scope dimension". For
+// PreapprovedMutatingTools, both nil and empty mean clear — the wire
+// payload always sends the field explicitly so operators have a
+// deterministic way to revoke preapproved mutations.
+type AgentScopeUpdate struct {
+	AgentID                  string
+	AllowedTools             []string
+	AllowedTopics            []string
+	AllowedPools             []string
+	DataClassifications      []string
+	PreapprovedMutatingTools []string
+	Status                   string
+	// IdempotencyKey, when non-empty, is sent as `Idempotency-Key`
+	// header so retries against the same intent collapse server-side.
+	IdempotencyKey string
+}
+
+// AgentClientConfig is the boot-time configuration for an AgentClient.
+type AgentClientConfig struct {
+	// BaseURL is the Cordum gateway root, e.g. https://gateway:8443.
+	// The client appends /api/v1/agents itself.
+	BaseURL string
+	// APIKey is the service-account credential; sent as `X-API-Key`
+	// when no per-call bearer token is provided.
+	APIKey string
+	// BearerToken, when non-empty, replaces X-API-Key on every call.
+	// Service accounts that mint per-session delegation tokens prefer
+	// this path.
+	BearerToken string
+	// Tenant, when non-empty, is sent as `X-Tenant-ID` so the gateway
+	// resolves the correct tenant scope.
+	Tenant string
+	// HTTPClient lets tests inject a transport. nil = http.DefaultClient
+	// with no timeout (the caller's context governs cancellation).
+	HTTPClient *http.Client
+}
+
+// AgentClient wraps Register / Lookup / SetScope against the Cordum
+// gateway's /api/v1/agents endpoints. Goroutine-safe.
+type AgentClient struct {
+	httpClient  *http.Client
+	baseURL     string
+	apiKey      string
+	bearerToken string
+	tenant      string
+}
+
+// NewAgentClient validates cfg and returns a ready-to-use client.
+func NewAgentClient(cfg AgentClientConfig) (*AgentClient, error) {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, errors.New("capsdk/agent: BaseURL is required")
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &AgentClient{
+		httpClient:  hc,
+		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
+		apiKey:      cfg.APIKey,
+		bearerToken: cfg.BearerToken,
+		tenant:      cfg.Tenant,
+	}, nil
+}
+
+// Register creates a new agent identity. Returns the server-assigned
+// agent_id on success. Per the AgentSpec note, PreapprovedMutatingTools
+// MUST be set via a follow-up SetScope call, not at register time.
+func (c *AgentClient) Register(ctx context.Context, spec AgentSpec) (string, error) {
+	if strings.TrimSpace(spec.Name) == "" {
+		return "", errors.New("capsdk/agent: Register: spec.Name is required")
+	}
+	body, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("capsdk/agent: marshal: %w", err)
+	}
+	var out AgentIdentity
+	if err := c.do(ctx, http.MethodPost, "/api/v1/agents", body, "", &out); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(out.ID) == "" {
+		return "", errors.New("capsdk/agent: Register: server returned empty agent id")
+	}
+	return out.ID, nil
+}
+
+// ErrAgentNotFound is returned by Lookup when no agent with the
+// requested name exists in the requested tenant scope.
+var ErrAgentNotFound = errors.New("capsdk/agent: not found")
+
+// ErrAgentDuplicate is returned by Lookup when more than one agent
+// with the requested name exists in scope. Caller must surface this
+// as an operator-visible error: bootstrapping cannot pick which is
+// the canonical identity.
+var ErrAgentDuplicate = errors.New("capsdk/agent: duplicate identity")
+
+// Lookup searches for an existing agent by name within the requested
+// tenant scope. Returns nil + ErrAgentNotFound if no match. Returns
+// ErrAgentDuplicate if multiple match (operator must resolve before
+// service can boot deterministically).
+//
+// Tenant filtering: when tenant is non-empty, the result MUST match
+// the supplied tenant. When tenant is empty, the gateway-side tenant
+// header (configured at NewAgentClient) is the scope.
+func (c *AgentClient) Lookup(ctx context.Context, name, tenant string) (*AgentIdentity, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, errors.New("capsdk/agent: Lookup: name is required")
+	}
+	q := url.Values{}
+	q.Set("name", name)
+	if t := strings.TrimSpace(tenant); t != "" {
+		q.Set("tenant", t)
+	}
+	path := "/api/v1/agents?" + q.Encode()
+	var resp struct {
+		Items []AgentIdentity `json:"items"`
+	}
+	if err := c.do(ctx, http.MethodGet, path, nil, "", &resp); err != nil {
+		return nil, err
+	}
+	matches := make([]AgentIdentity, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		if !strings.EqualFold(item.Name, name) {
+			continue
+		}
+		matches = append(matches, item)
+	}
+	switch len(matches) {
+	case 0:
+		return nil, ErrAgentNotFound
+	case 1:
+		out := matches[0]
+		return &out, nil
+	default:
+		return nil, fmt.Errorf("%w: name=%q tenant=%q count=%d", ErrAgentDuplicate, name, tenant, len(matches))
+	}
+}
+
+// SetScope applies the scope update to an existing agent. PUT
+// /api/v1/agents/{id} with the explicit allowed_*/preapproved_*
+// fields. Idempotency-Key, when supplied, lets retries fold safely
+// at the server.
+//
+// PreapprovedMutatingTools is ALWAYS sent (even empty []) so an
+// operator can deterministically revoke. Other fields (AllowedTopics
+// etc.) follow nil=leave, []=clear semantics matching the gateway.
+func (c *AgentClient) SetScope(ctx context.Context, update AgentScopeUpdate) error {
+	id := strings.TrimSpace(update.AgentID)
+	if id == "" {
+		return errors.New("capsdk/agent: SetScope: AgentID is required")
+	}
+	body := map[string]any{}
+	if update.AllowedTools != nil {
+		body["allowed_tools"] = append([]string{}, update.AllowedTools...)
+	}
+	if update.AllowedTopics != nil {
+		body["allowed_topics"] = append([]string{}, update.AllowedTopics...)
+	}
+	if update.AllowedPools != nil {
+		body["allowed_pools"] = append([]string{}, update.AllowedPools...)
+	}
+	if update.DataClassifications != nil {
+		body["data_classifications"] = append([]string{}, update.DataClassifications...)
+	}
+	// Always send preapproved_mutating_tools — empty slice means
+	// "revoke all preapproved mutations", which must be deterministic.
+	body["preapproved_mutating_tools"] = append([]string{}, update.PreapprovedMutatingTools...)
+	if v := strings.TrimSpace(update.Status); v != "" {
+		body["status"] = v
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("capsdk/agent: marshal: %w", err)
+	}
+	path := "/api/v1/agents/" + url.PathEscape(id)
+	return c.do(ctx, http.MethodPut, path, raw, update.IdempotencyKey, nil)
+}
+
+// do is the shared request path. Auth hierarchy: bearer token (when
+// non-empty) replaces X-API-Key entirely, so a per-session delegation
+// token does not leak the service-account API key downstream.
+func (c *AgentClient) do(ctx context.Context, method, path string, body []byte, idempotencyKey string, out any) error {
+	full := c.baseURL + path
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, full, bodyReader)
+	if err != nil {
+		return fmt.Errorf("capsdk/agent: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	} else if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+	if c.tenant != "" {
+		req.Header.Set("X-Tenant-ID", c.tenant)
+	}
+	if k := strings.TrimSpace(idempotencyKey); k != "" {
+		req.Header.Set("Idempotency-Key", k)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("capsdk/agent: %s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Cap response read at 4 MiB so a misbehaving gateway can't OOM
+	// the SDK caller.
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<22))
+	if readErr != nil {
+		return fmt.Errorf("capsdk/agent: read body: %w", readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &AgentAPIError{
+			StatusCode: resp.StatusCode,
+			Method:     method,
+			Path:       path,
+			Body:       truncateBody(string(respBody), 1024),
+		}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("capsdk/agent: decode body: %w", err)
+	}
+	return nil
+}
+
+// AgentAPIError wraps a non-2xx response from the agent endpoints.
+// Callers use errors.As to inspect StatusCode for retry / typed
+// handling.
+type AgentAPIError struct {
+	StatusCode int
+	Method     string
+	Path       string
+	Body       string
+}
+
+func (e *AgentAPIError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("capsdk/agent: %s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("capsdk/agent: %s %s: status %d", e.Method, e.Path, e.StatusCode)
+}
+
+func truncateBody(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/sdk/go/agent_test.go
+++ b/sdk/go/agent_test.go
@@ -1,0 +1,371 @@
+package capsdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestAgentClient(t *testing.T, baseURL string) *AgentClient {
+	t.Helper()
+	c, err := NewAgentClient(AgentClientConfig{
+		BaseURL: baseURL,
+		APIKey:  "svc-test-key",
+		Tenant:  "tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient: %v", err)
+	}
+	return c
+}
+
+func TestNewAgentClient_RequiresBaseURL(t *testing.T) {
+	t.Parallel()
+	if _, err := NewAgentClient(AgentClientConfig{}); err == nil {
+		t.Fatal("expected error for empty BaseURL")
+	}
+}
+
+// Register: POSTs /api/v1/agents, sends spec fields, does NOT include
+// preapproved_mutating_tools (rail #2), and surfaces server-assigned id.
+func TestAgentClient_Register_Success(t *testing.T) {
+	t.Parallel()
+	var seenMethod, seenPath, seenAPIKey, seenTenant string
+	var bodyBytes []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		seenAPIKey = r.Header.Get("X-API-Key")
+		seenTenant = r.Header.Get("X-Tenant-ID")
+		bodyBytes, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(AgentIdentity{
+			ID:        "agent-uuid-1",
+			Name:      "chat-assistant",
+			Owner:     "platform",
+			RiskTier:  "medium",
+			Status:    "active",
+			CreatedAt: "2026-04-26T10:00:00Z",
+			UpdatedAt: "2026-04-26T10:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestAgentClient(t, srv.URL)
+	id, err := c.Register(context.Background(), AgentSpec{
+		Name:          "chat-assistant",
+		Owner:         "platform",
+		RiskTier:      "medium",
+		AllowedTools:  []string{"cordum_list_jobs", "cordum_submit_job"},
+		AllowedTopics: []string{"job.*"},
+	})
+	if err != nil {
+		t.Fatalf("Register err: %v", err)
+	}
+	if id != "agent-uuid-1" {
+		t.Errorf("id = %q, want agent-uuid-1", id)
+	}
+	if seenMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", seenMethod)
+	}
+	if seenPath != "/api/v1/agents" {
+		t.Errorf("path = %q, want /api/v1/agents", seenPath)
+	}
+	if seenAPIKey != "svc-test-key" {
+		t.Errorf("X-API-Key = %q", seenAPIKey)
+	}
+	if seenTenant != "tenant-a" {
+		t.Errorf("X-Tenant-ID = %q", seenTenant)
+	}
+	// Critical: preapproved_mutating_tools MUST NOT appear in the
+	// register payload (rail #2).
+	if strings.Contains(string(bodyBytes), "preapproved_mutating_tools") {
+		t.Errorf("Register sent preapproved_mutating_tools — rail #2 violation: body=%s", bodyBytes)
+	}
+	// allowed_tools should appear.
+	if !strings.Contains(string(bodyBytes), "allowed_tools") {
+		t.Errorf("Register did not send allowed_tools: body=%s", bodyBytes)
+	}
+}
+
+func TestAgentClient_Register_RequiresName(t *testing.T) {
+	t.Parallel()
+	c := newTestAgentClient(t, "http://localhost")
+	if _, err := c.Register(context.Background(), AgentSpec{Owner: "p", RiskTier: "low"}); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestAgentClient_Register_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	_, err := c.Register(context.Background(), AgentSpec{Name: "x", Owner: "y", RiskTier: "low"})
+	var apiErr *AgentAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *AgentAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want 403", apiErr.StatusCode)
+	}
+}
+
+// Lookup: GETs /api/v1/agents with name+tenant query, filters by name
+// case-insensitive, returns ErrAgentNotFound on no match,
+// ErrAgentDuplicate on multi-match.
+func TestAgentClient_Lookup_Hit(t *testing.T) {
+	t.Parallel()
+	var seenQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []AgentIdentity{
+				{ID: "agent-1", Name: "chat-assistant", Owner: "platform", RiskTier: "medium", Status: "active"},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	got, err := c.Lookup(context.Background(), "chat-assistant", "tenant-a")
+	if err != nil {
+		t.Fatalf("Lookup err: %v", err)
+	}
+	if got == nil || got.ID != "agent-1" {
+		t.Fatalf("got = %+v, want id=agent-1", got)
+	}
+	if !strings.Contains(seenQuery, "name=chat-assistant") {
+		t.Errorf("query = %q, want name=chat-assistant", seenQuery)
+	}
+	if !strings.Contains(seenQuery, "tenant=tenant-a") {
+		t.Errorf("query = %q, want tenant=tenant-a", seenQuery)
+	}
+}
+
+func TestAgentClient_Lookup_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []AgentIdentity{}})
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	got, err := c.Lookup(context.Background(), "missing", "tenant-a")
+	if !errors.Is(err, ErrAgentNotFound) {
+		t.Fatalf("err = %v, want ErrAgentNotFound", err)
+	}
+	if got != nil {
+		t.Errorf("got = %+v, want nil", got)
+	}
+}
+
+func TestAgentClient_Lookup_Duplicate(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []AgentIdentity{
+				{ID: "agent-1", Name: "chat-assistant"},
+				{ID: "agent-2", Name: "chat-assistant"},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	_, err := c.Lookup(context.Background(), "chat-assistant", "tenant-a")
+	if !errors.Is(err, ErrAgentDuplicate) {
+		t.Fatalf("err = %v, want ErrAgentDuplicate", err)
+	}
+}
+
+// Server returns extra rows that don't match the requested name —
+// client filters them out.
+func TestAgentClient_Lookup_FiltersByName(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []AgentIdentity{
+				{ID: "agent-x", Name: "other-agent"},
+				{ID: "agent-1", Name: "chat-assistant"},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	got, err := c.Lookup(context.Background(), "chat-assistant", "")
+	if err != nil {
+		t.Fatalf("Lookup err: %v", err)
+	}
+	if got.ID != "agent-1" {
+		t.Errorf("got.ID = %q, want agent-1", got.ID)
+	}
+}
+
+func TestAgentClient_Lookup_RequiresName(t *testing.T) {
+	t.Parallel()
+	c := newTestAgentClient(t, "http://localhost")
+	if _, err := c.Lookup(context.Background(), "", ""); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+// SetScope: PUT /api/v1/agents/{id}, sends preapproved_mutating_tools
+// always (even empty), respects nil=leave for other fields.
+func TestAgentClient_SetScope_SendsPreapprovedExplicitly(t *testing.T) {
+	t.Parallel()
+	var seenMethod, seenPath, seenIdempotency string
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		seenIdempotency = r.Header.Get("Idempotency-Key")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestAgentClient(t, srv.URL)
+	err := c.SetScope(context.Background(), AgentScopeUpdate{
+		AgentID:                  "agent-1",
+		AllowedTools:             []string{"cordum_list_jobs", "cordum_submit_job"},
+		PreapprovedMutatingTools: []string{"cordum_submit_job"},
+		Status:                   "active",
+		IdempotencyKey:           "boot-2026-04-26",
+	})
+	if err != nil {
+		t.Fatalf("SetScope err: %v", err)
+	}
+	if seenMethod != http.MethodPut {
+		t.Errorf("method = %s, want PUT", seenMethod)
+	}
+	if seenPath != "/api/v1/agents/agent-1" {
+		t.Errorf("path = %q", seenPath)
+	}
+	if seenIdempotency != "boot-2026-04-26" {
+		t.Errorf("Idempotency-Key = %q, want boot-2026-04-26", seenIdempotency)
+	}
+	// Critical: preapproved_mutating_tools field MUST be in the body
+	// even when caller passed nil/empty (rail: deterministic revoke).
+	if _, ok := body["preapproved_mutating_tools"]; !ok {
+		t.Errorf("body missing preapproved_mutating_tools: %+v", body)
+	}
+	// allowed_tools sent
+	if _, ok := body["allowed_tools"]; !ok {
+		t.Errorf("body missing allowed_tools: %+v", body)
+	}
+	// allowed_topics NOT sent (nil=leave)
+	if _, ok := body["allowed_topics"]; ok {
+		t.Errorf("body contains allowed_topics despite nil input: %+v", body)
+	}
+}
+
+// Empty PreapprovedMutatingTools must STILL appear (revoke-all
+// semantics).
+func TestAgentClient_SetScope_EmptyPreapprovedSendsExplicitly(t *testing.T) {
+	t.Parallel()
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	if err := c.SetScope(context.Background(), AgentScopeUpdate{
+		AgentID:                  "agent-1",
+		PreapprovedMutatingTools: []string{},
+	}); err != nil {
+		t.Fatalf("SetScope err: %v", err)
+	}
+	v, ok := body["preapproved_mutating_tools"]
+	if !ok {
+		t.Fatalf("body missing preapproved_mutating_tools: %+v", body)
+	}
+	arr, ok := v.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("preapproved_mutating_tools = %v, want []", v)
+	}
+}
+
+func TestAgentClient_SetScope_RequiresAgentID(t *testing.T) {
+	t.Parallel()
+	c := newTestAgentClient(t, "http://localhost")
+	if err := c.SetScope(context.Background(), AgentScopeUpdate{}); err == nil {
+		t.Fatal("expected error for empty AgentID")
+	}
+}
+
+// Bearer token replaces X-API-Key (per-call delegation tokens never
+// accompany the service key).
+func TestAgentClient_BearerSupplantsAPIKey(t *testing.T) {
+	t.Parallel()
+	var seenAuth, seenAPIKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenAPIKey = r.Header.Get("X-API-Key")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []AgentIdentity{}})
+	}))
+	defer srv.Close()
+	c, err := NewAgentClient(AgentClientConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "svc-test-key",
+		BearerToken: "delegation-token-abc",
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient: %v", err)
+	}
+	_, _ = c.Lookup(context.Background(), "x", "")
+	if seenAuth != "Bearer delegation-token-abc" {
+		t.Errorf("Authorization = %q, want Bearer delegation-token-abc", seenAuth)
+	}
+	if seenAPIKey != "" {
+		t.Errorf("X-API-Key = %q, want empty (bearer must replace, not accompany)", seenAPIKey)
+	}
+}
+
+// Context cancellation surfaces as ctx error.
+func TestAgentClient_CtxCancel(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := c.Lookup(ctx, "x", "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// Counter test: SetScope makes exactly one HTTP request.
+func TestAgentClient_SetScope_SingleRequest(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := newTestAgentClient(t, srv.URL)
+	if err := c.SetScope(context.Background(), AgentScopeUpdate{AgentID: "agent-1"}); err != nil {
+		t.Fatalf("SetScope err: %v", err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("hits = %d, want 1", hits.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Source-of-truth Go SDK wrappers for the Cordum control-plane agent endpoints. Closes the phase-3 gap noted in cordum/core/llmchat/bootstrap.go where the chat-assistant bootstrap falls back to MCP cordum_register_agent + cordum_set_agent_scope because no native CAP wrappers existed.

Tracks cordum task-cc03a68d (cap-side scope only).

## API

- **AgentClient.Register(ctx, AgentSpec) (string, error)** — POST /api/v1/agents. AgentSpec deliberately omits preapproved_mutating_tools (rail #2 — preapproved mutations are a SetScope privilege, not a create-time grant).
- **AgentClient.Lookup(ctx, name, tenant) (*AgentIdentity, error)** — GET /api/v1/agents with name+tenant query. ErrAgentNotFound on miss; ErrAgentDuplicate on multi-match. Client-side case-insensitive name filter so tenant scoping survives loose-match server responses.
- **AgentClient.SetScope(ctx, AgentScopeUpdate) error** — PUT /api/v1/agents/{id}. Nil slices = leave; \`[]\` = clear; preapproved_mutating_tools is ALWAYS sent (even empty) so operators have a deterministic revoke path. Idempotency-Key forwarded.

## Auth

Bearer token (when set on client) replaces X-API-Key entirely — per-session delegation tokens never leak the service-account key downstream.

## Tests

\`cap/sdk/go/agent_test.go\` — 14 cases covering Register success/empty-name/server-error, Lookup hit/notfound/duplicate/name-filter/empty-name, SetScope preapproved-explicit/empty-explicit/empty-id/single-request, bearer-supplants-API-key, ctx-cancel.

## Verification

\`\`\`
cd cap && go test ./sdk/go/... -count=3 -timeout 120s
ok  github.com/cordum-io/cap/v2/sdk/go        0.269s
ok  github.com/cordum-io/cap/v2/sdk/go/client 0.726s
ok  github.com/cordum-io/cap/v2/sdk/go/runtime 1.331s
ok  github.com/cordum-io/cap/v2/sdk/go/testing 0.921s
ok  github.com/cordum-io/cap/v2/sdk/go/worker  19.966s

go vet ./sdk/go/...   # exit 0
go build ./sdk/go/... # exit 0
\`\`\`

## Cordum-side migration (NOT in this PR)

The Moe task task-cc03a68d also covers migrating cordum/core/llmchat/bootstrap.go to use these wrappers. That requires:
1. A cap version tag bump (so cordum's \`github.com/cordum-io/cap/v2 v2.9.3\` import sees the new symbols), OR a workspace replace directive
2. Adding a \`PreapprovedMutatingTools\` field to gateway \`updateAgentRequest\` (handlers_agents.go) — currently the existing MCP bridge sends the field but the gateway silently drops it
3. Migrating bootstrap.go + its tests to use AgentClient
4. Removing the MCP fallback path (pre-GA, no compat shims)

Filing as cordum-side follow-up.

## Test plan

- [x] \`go test ./sdk/go/... -count=3\` green locally
- [ ] CI green
- [ ] Tag bump (e.g. v2.10.0) once merged so cordum can import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go SDK: agent management (register, lookup, update scope) with bearer-token/API-key auth, tenant header support, and idempotent scope updates.
* **Documentation**
  * New agent registration guide detailing lookup/register/set-scope semantics, deterministic revocation via explicit preapproval payloads, and bootstrap/first-boot behavior.
* **Tests**
  * Comprehensive test suite covering validations, auth precedence, request/response semantics, idempotency, and deterministic payload behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->