### PR TITLE
chore(ci): bump Go toolchain to fix GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cordum-io/cap/v2
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
Bumps go.mod's Go directive from 1.25.11 to 1.25.12, fixing GO-2026-5856 (crypto/tls ECH pre-shared-key identity disclosure, CVE-2026-42505) which the required 'Go SDK' govulncheck status check has been flagging on main itself — currently blocking every PR on this repo, including trivial dependency bumps.

All three Go CI workflows (ci.yml, codeql.yml, publish-go.yml) use actions/setup-go with go-version-file: go.mod, so this single go.mod change is sufficient — no separate workflow YAML edits needed.

Verified locally with go1.26.3 (GOTOOLCHAIN=auto satisfies the new 1.25.12 minimum): go build ./... clean.