### PR TITLE
[P0] node: repair published artifact, dispatch, and signature enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,51 @@ jobs:
           govulncheck ./...
 
   node:
-    name: Node SDK
+    name: Node SDK (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: sdk/node/package-lock.json
+
+      - name: Install dependencies
+        working-directory: sdk/node
+        run: npm ci
+
+      - name: Run source tests
+        working-directory: sdk/node
+        run: npm test
+
+      - name: Build package
+        working-directory: sdk/node
+        run: npm run build
+
+      - name: Verify installed package
+        working-directory: sdk/node
+        run: npm run test:package
+
+      - name: Lint package metadata
+        working-directory: sdk/node
+        run: npm run lint:package
+
+      - name: Audit production dependencies
+        working-directory: sdk/node
+        run: npm audit --omit=dev --audit-level=high
+
+  node-nats:
+    name: Node SDK (real NATS v2.10.25)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -53,9 +96,12 @@ jobs:
         working-directory: sdk/node
         run: npm ci
 
-      - name: Run tests
+      - name: Pull pinned NATS server
+        run: docker pull nats:2.10.25-alpine
+
+      - name: Run mandatory real-NATS restart test
         working-directory: sdk/node
-        run: npm test
+        run: npm run test:nats
 
   python:
     name: Python SDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         node-version: ['18', '20', '22']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -84,6 +86,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -10,13 +10,20 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: publish-node-${{ github.event.inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         shell: bash
         working-directory: sdk/node
+    env:
+      CAP_NODE_PACK_DIR: ${{ runner.temp }}/cap-node-package
     permissions:
       contents: read
     steps:
@@ -28,11 +35,14 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: sdk/node/package-lock.json
 
       - name: Set version from tag
         env:
           VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
+          set -euo pipefail
           if [[ -z "${VERSION}" ]]; then
             echo "VERSION not set from tag"; exit 1
           fi
@@ -42,18 +52,63 @@ jobs:
           fi
           CURRENT_VERSION="$(node -p "require('./package.json').version")"
           if [[ "${CURRENT_VERSION}" != "${VERSION}" ]]; then
-            npm version "$VERSION" --no-git-tag-version
+            npm version "${VERSION}" --no-git-tag-version
           else
             echo "package.json already at version ${VERSION}"
           fi
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install locked dependencies
+        run: npm ci
 
-      - name: Build
+      - name: Run source tests
+        run: npm test
+
+      - name: Build package
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Lint package metadata
+        run: npm run lint:package
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Pull pinned NATS server
+        run: docker pull nats:2.10.25-alpine
+
+      - name: Run mandatory real-NATS restart test
+        run: npm run test:nats
+
+      - name: Pack release artifact exactly once
+        id: pack
+        run: |
+          set -euo pipefail
+          rm -rf -- "${CAP_NODE_PACK_DIR}"
+          mkdir -p "${CAP_NODE_PACK_DIR}"
+          PACK_JSON="${CAP_NODE_PACK_DIR}/pack.json"
+          npm pack --json --pack-destination "${CAP_NODE_PACK_DIR}" > "${PACK_JSON}"
+          TARBALL="$(node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const [jsonPath, packDir] = process.argv.slice(1);
+            const entries = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+            if (!Array.isArray(entries) || entries.length !== 1 || !entries[0].filename) process.exit(2);
+            process.stdout.write(path.join(packDir, entries[0].filename));
+          ' "${PACK_JSON}" "${CAP_NODE_PACK_DIR}")"
+          test -f "${TARBALL}"
+          echo "tarball=${TARBALL}" >> "${GITHUB_OUTPUT}"
+          echo "pack_json=${PACK_JSON}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify exact release artifact
+        run: >-
+          node scripts/verify-package.cjs
+          --tarball "${{ steps.pack.outputs.tarball }}"
+          --pack-json "${{ steps.pack.outputs.pack_json }}"
+
+      - name: Publish verified artifact to npm
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Clean release artifact
+        if: always()
+        run: rm -rf -- "${CAP_NODE_PACK_DIR}"

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -22,13 +22,13 @@ jobs:
       run:
         shell: bash
         working-directory: sdk/node
-    env:
-      CAP_NODE_PACK_DIR: ${{ runner.temp }}/cap-node-package
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -80,6 +80,8 @@ jobs:
 
       - name: Pack release artifact exactly once
         id: pack
+        env:
+          CAP_NODE_PACK_DIR: ${{ runner.temp }}/cap-node-package
         run: |
           set -euo pipefail
           rm -rf -- "${CAP_NODE_PACK_DIR}"
@@ -111,4 +113,6 @@ jobs:
 
       - name: Clean release artifact
         if: always()
+        env:
+          CAP_NODE_PACK_DIR: ${{ runner.temp }}/cap-node-package
         run: rm -rf -- "${CAP_NODE_PACK_DIR}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Entries are grouped by SDK release tag. Wire schema changes (protobuf field addi
 
 ## Unreleased — Protocol Hardening
 
+- **Node SDK (non-wire bugfix):** Repaired npm artifacts to bundle all runtime protobuf
+  schemas, corrected NATS callback dispatch and shutdown/reconnect lifecycle handling, and
+  made configured inbound signature verification fail closed before handlers run. No
+  protobuf schema or protocol-version change.
 - **Go SDK:** Fixed worker heartbeat/progress/cancel payload builders so freshly-built `BusPacket`s pass the SDK's own `ValidateBusPacket`: `HeartbeatPayloadWithProgress` now sets `TraceId=workerID` and `CreatedAt`, and `ProgressPayload` / `CancelPayload` now set `TraceId=jobID`. This is not a [WIRE] change; it populates existing envelope fields without changing protobuf schema or protocol version.
 - **Python/Node SDKs:** Matched Go SDK parity for heartbeat/progress/cancel payload builders by setting heartbeat `trace_id`/`traceId` to the worker id, progress/cancel `trace_id`/`traceId` to the job id, and stamping `created_at` in these helper-built envelopes so packets pass SDK `BusPacket` validation. This is not a [WIRE] change; it populates existing envelope fields without changing protobuf schema or protocol version.
 - **[WIRE]** Added `agent_name` field (19) to `Heartbeat` and `agent_name` field (7) to `Handshake` — an optional human-facing display label (e.g. `Claude Code — Billing Bot`) for dashboard and audit attribution. Additive/append-only; existing clients stay wire-compatible (old clients send empty). It is a DISPLAY label only and **not an authentication authority**: consumers MUST prefer authenticated identity records (worker credential / Agent Identity) over this self-reported value and MUST NOT use it for authorization. Regenerated Go and Python descriptors; C++/Node-generated stubs unchanged (additive field — regenerate via the pinned toolchain in CI).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,8 @@ signature verification failed for sender <sender-id>
 invalid signature: ECDSA verify failed
 ```
 
-**Cause:** Key format mismatch, wrong key, or non-deterministic serialization.
+**Cause:** Key format mismatch, wrong or missing sender mapping, an unsigned packet in strict
+mode, or non-deterministic serialization.
 
 **Solution:**
 
@@ -103,9 +104,18 @@ invalid signature: ECDSA verify failed
      node -e "const {generateKeyPairSync}=require('crypto');const {privateKey,publicKey}=generateKeyPairSync('ec',{namedCurve:'prime256v1',publicKeyEncoding:{type:'spki',format:'pem'},privateKeyEncoding:{type:'pkcs8',format:'pem'}});console.log(privateKey);console.log(publicKey);"
      ```
 
-3. **Ensure the public key map matches sender IDs.** The `publicKeyMap`/`public_keys` must map sender IDs to the correct public keys. A mismatch causes verification failure.
+3. **Ensure the public key map matches sender IDs.** The `publicKeyMap`/`public_keys`
+   must map sender IDs to the correct public keys. A mismatch causes verification failure.
 
-4. **Cross-SDK verification** works because all SDKs use deterministic protobuf serialization (map entries sorted by key). If you're using a custom serializer, ensure it produces deterministic output.
+4. **For Node, check strict-mode configuration.** Omitting `publicKeyMap` (or setting it
+   to `undefined`) is the sole legacy opt-out. Supplying any map enables strict verification;
+   `{}` denies every sender. Missing senders, unsigned packets, unknown keys, malformed
+   envelopes, and invalid signatures are dropped before either `startWorker` or `Agent`
+   calls a handler.
+
+5. **Cross-SDK verification** works because all SDKs use deterministic protobuf serialization
+   (map entries sorted by key). If you're using a custom serializer, ensure it produces
+   deterministic output.
 
 ---
 
@@ -116,18 +126,40 @@ invalid signature: ECDSA verify failed
 proto: cannot parse invalid wire-format data
 ModuleNotFoundError: No module named 'cap.pb.cordum.agent.v1'
 Cannot find module '../cordum/agent/v1/job.proto'
+ENOENT: no such file or directory, open '.../cordum/agent/v1/alert.proto'
 ```
 
-**Cause:** Stale or missing generated protobuf stubs.
+**Cause:** Invalid or version-mismatched wire bytes, stale generated stubs, or an old/corrupt
+SDK install.
 
 **Solution:**
 
-1. **Regenerate stubs** from the repo root:
+1. **For a released Node package, verify and refresh the install:**
+   ```bash
+   npm ls cap-sdk-node
+   npm cache verify
+   npm install cap-sdk-node@latest
+   ```
+   Released Node artifacts bundle the seven required schemas under
+   `node_modules/cap-sdk-node/dist/proto/cordum/agent/v1`. Node application consumers do not
+   need `protoc` or a full CAP clone. If the directory is absent, update an older lockfile or
+   version, or replace the corrupt install rather than copying schemas from a repository
+   checkout.
+
+2. **For Node SDK source development**, build from the full CAP checkout:
+   ```bash
+   cd sdk/node
+   npm ci
+   npm run build
+   ```
+   The build copies the canonical repository schemas into `dist`; it does not require `protoc`.
+
+3. **Regenerate Go and Python stubs** from the repo root when changing protocol sources:
    ```bash
    ./tools/make_protos.sh
    ```
 
-2. **For Python** stubs specifically:
+4. **For Python** stubs specifically:
    ```bash
    CAP_RUN_PY=1 ./tools/make_protos.sh
    ```
@@ -141,14 +173,13 @@ Cannot find module '../cordum/agent/v1/job.proto'
      ../../proto/cordum/agent/v1/*.proto
    ```
 
-3. **Check protoc version.** CAP proto files use proto3 syntax. Install `protoc` v3.19+ or use `grpc_tools.protoc` (Python) / `protobufjs` (Node).
+5. **Check the generator version for source changes.** CAP proto files use proto3 syntax.
+   Use the repository's pinned generation workflow; Python can use `grpc_tools.protoc`.
 
-4. **For Go**, stubs live at `cordum/agent/v1/` in the repo root. The import path is:
+6. **For Go**, stubs live at `cordum/agent/v1/` in the repo root. The import path is:
    ```go
    agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
    ```
-
-5. **For Node**, protobufjs loads `.proto` files at runtime from `proto/`. If the proto files are missing, ensure you cloned the full repository.
 
 ---
 
@@ -203,7 +234,9 @@ Cannot find module '../cordum/agent/v1/job.proto'
    nats server report connections
    ```
 
-4. **Queue group issues:** CAP workers use `cap-workers` as the default queue group. If you have a custom queue group, ensure all workers for the same subject use the same group.
+4. **Queue group issues:** Ensure workers for the same subject intentionally share a queue
+   group. In Node, `startWorker()` defaults the queue to its subject, and `Agent` uses each
+   handler topic as its queue.
 
 ---
 
@@ -325,7 +358,8 @@ python -m grpc_tools.protoc \
 2. **For the low-level SDK**, heartbeats are manual. Use the heartbeat helpers:
    - **Go:** `capsdk.HeartbeatPayload()` or `capsdk.HeartbeatPayloadWithMemory()`
    - **Python:** Heartbeats are sent automatically by `run_worker()` if `heartbeat_interval` is set.
-   - **Node:** Heartbeats are sent by `startWorker()` when configured.
+   - **Node:** High-level `Agent.start()` starts the heartbeat loop. Low-level
+     `startWorker()` does not; use `heartbeatLoop()` or `emitHeartbeat()` explicitly.
 
 3. **Monitor heartbeats:**
    ```bash

--- a/sdk/node/.gitignore
+++ b/sdk/node/.gitignore
@@ -1,1 +1,2 @@
 docs/
+.build/

--- a/sdk/node/LICENSE
+++ b/sdk/node/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2025 The cordum Agent Protocol Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -1,42 +1,60 @@
 # CAP Node/TypeScript SDK
 
-Node/TS SDK with NATS helpers. Uses `protobufjs` to load CAP proto definitions at runtime.
+Node/TypeScript SDK with NATS helpers and runtime-loaded CAP protobuf definitions.
 
-## Quick Start
-1. Install deps:
-   ```bash
-   cd sdk/node
-   npm install
-   ```
-2. Run the sample worker:
-   ```bash
-   npm run build
-   node dist/sample-worker.js
-   ```
+## Install
 
-3. Submit a job (client):
-   ```ts
-   import { connectNATS } from "./bus";
-   import { submitJob } from "./client";
+```bash
+npm install cap-sdk-node
+```
 
-   async function main() {
-     const nc = await connectNATS({ url: "nats://127.0.0.1:4222" });
-    await submitJob(
-      nc,
-      {
-        jobId: "job-echo-1",
-        topic: "job.echo",
-        contextPtr: "redis://ctx/job-echo-1",
-       },
-      "trace-1",
-      "client-node",
-      "<PEM_PRIVATE_KEY>"
-    );
-     await nc.drain();
-   }
+The released npm artifact bundles the CAP schemas required by `loadRoot()`.
+Application consumers do not need `protoc`, generated stubs, or a CAP repository clone.
 
-   main().catch(console.error);
-   ```
+The package is CommonJS and supports both CommonJS and native ESM consumers:
+
+```js
+const { connectNATS, loadRoot, submitJob } = require("cap-sdk-node");
+```
+
+```ts
+import { connectNATS, loadRoot, submitJob } from "cap-sdk-node";
+```
+
+`loadRoot()` is asynchronous; await it before looking up protobuf types.
+
+## Submit a job
+
+```ts
+import { connectNATS, submitJob } from "cap-sdk-node";
+
+async function main() {
+  const nc = await connectNATS({ url: "nats://127.0.0.1:4222" });
+  await submitJob(
+    nc,
+    {
+      jobId: "job-echo-1",
+      topic: "job.echo",
+      contextPtr: "redis://ctx/job-echo-1",
+    },
+    "trace-1",
+    "client-node",
+    "<PEM_PRIVATE_KEY>",
+  );
+  await nc.drain();
+}
+
+main().catch(console.error);
+```
+
+## Develop this SDK from source
+
+```bash
+cd sdk/node
+npm ci
+npm run build
+node dist/sample-worker.js
+```
 
 ## Files
 - `src/protos.ts` — loads CAP protos via protobufjs.
@@ -50,7 +68,7 @@ The runtime hides NATS/Redis plumbing and gives you typed handlers.
 
 ```ts
 import { z } from "zod";
-import { Agent } from "./runtime";
+import { Agent } from "cap-sdk-node";
 
 const Input = z.object({ prompt: z.string() });
 const Output = z.object({ summary: z.string() });
@@ -65,7 +83,8 @@ agent.run().catch(console.error);
 ```
 
 ### Validation
-The Node SDK provides opt-in validation helpers for CAP protobuf messages. Each function returns an array of `ValidationError` objects; an empty array means the message is valid.
+The Node SDK provides opt-in validation helpers for CAP protobuf messages. Each function
+returns an array of `ValidationError` objects; an empty array means the message is valid.
 
 - `validateJobRequest(msg: any): ValidationError[]`
 - `validateJobResult(msg: any): ValidationError[]`
@@ -80,9 +99,35 @@ if (errors.length > 0) {
 }
 ```
 
+### Signature verification
+
+Inbound envelope validation always runs before a worker handler. Signature verification
+has two explicit modes on both `startWorker` and `Agent`:
+
+- `publicKeyMap: undefined` (or omitting the option) is the sole legacy opt-out from
+  signature verification.
+- Supplying any map enables strict verification. The sender ID and signature must be
+  nonempty, and the map must own a nonempty PEM public key for that sender. An empty map
+  (`{}`) therefore denies every sender.
+
+Unsigned packets, missing or unknown senders, malformed envelopes, and invalid or tampered
+signatures are rejected before the registered handler is called. Do not use `{}` to request
+unsigned compatibility.
+
 ### Environment
 - `NATS_URL` (default `nats://127.0.0.1:4222`)
 - `REDIS_URL` (default `redis://127.0.0.1:6379/0`)
+
+### Shutdown and resource ownership
+
+`startWorker()` is the low-level API and returns its NATS `Subscription`. The caller owns
+that subscription and the supplied NATS connection; drain or unsubscribe the subscription
+before draining the connection.
+
+`Agent` owns the NATS connection and blob store configured for it, including injected
+implementations. `await agent.close()` stops new intake, waits for in-flight handlers and
+result publication, drains the NATS connection, and closes the blob store. Repeated `close()`
+calls share the same shutdown operation.
 
 ## Testing
 
@@ -102,7 +147,8 @@ it("runs echo handler without NATS", async () => {
 ```
 
 - `testHandler(handler, input, options?)` — runs a single handler invocation and returns the result.
-- `createTestAgent(options?)` — returns `{ agent, bus, store }` pre-wired with `MockNatsConnection` + `InMemoryBlobStore`.
+- `createTestAgent(options?)` — returns `{ agent, bus, store }` pre-wired with
+  `MockNatsConnection` and `InMemoryBlobStore`.
 - `MockNatsConnection` — in-memory NATS mock for custom test setups.
 
 ## Middleware
@@ -141,7 +187,11 @@ Output is written to `docs/` (gitignored). Open `docs/index.html` to browse.
 ## Observability
 
 ### Structured Logging
-The runtime Agent and Worker accept a `Logger` for structured logging. All log calls include contextual fields (`jobId`, `traceId`, `topic`, `senderId`). Pass a custom logger or leave undefined for the built-in JSON logger:
+
+The runtime Agent and Worker accept a `Logger` for structured logging. Operational logs add
+job, trace, topic, or sender context when available. Security-rejection logs intentionally
+omit untrusted packet payloads and sender metadata. Pass a custom logger or omit it to use
+the standard `console` logger:
 
 ```ts
 import { Agent, Logger } from "cap-sdk-node";
@@ -184,16 +234,20 @@ const metrics: MetricsHook = {
 const agent = new Agent({ metrics });
 ```
 
-The `traceId` is propagated through all log and metrics calls for distributed tracing correlation.
+Job-scoped runtime logs include `traceId`. `MetricsHook` receives the job, topic, duration,
+status, error, and worker fields shown above; add trace correlation in your adapter if needed.
 
 ## Notes
 - Subjects: `sys.job.submit`, `job.<pool>`, `sys.job.result`, `sys.heartbeat`.
 - Protocol version: `1`.
-- Field names use camelCase in protobufjs objects (e.g., `jobId`, `contextPtr`, `resultPtr`, `workerId`).
-- Swap `bus.ts` for another transport if needed; keep message encoding via protobufjs or precompiled static modules (`pbjs/pbts`).
-- Signing: `submitJob` and `startWorker` sign envelopes when given a PEM private key; set `publicKeyMap` to verify incoming packets. Signatures use deterministic protobuf serialization (map entries ordered by key) for cross-SDK verification. Generate a P-256 keypair with:
+- Field names use camelCase in protobufjs objects (for example, `jobId`, `contextPtr`,
+  `resultPtr`, and `workerId`).
+- The runtime transport covered by this SDK is NATS; publish protobuf-encoded CAP
+  `BusPacket` envelopes on CAP subjects.
+- Signing: `submitJob` and `startWorker` sign envelopes when given a PEM private key. Signatures use
+  deterministic protobuf serialization (map entries ordered by key) for cross-SDK
+  verification. Generate a P-256 keypair with:
   ```bash
   node -e "const {generateKeyPairSync}=require('crypto');const {privateKey,publicKey}=generateKeyPairSync('ec',{namedCurve:'prime256v1',publicKeyEncoding:{type:'spki',format:'pem'},privateKeyEncoding:{type:'pkcs8',format:'pem'}});console.log(privateKey);console.log(publicKey);"
   ```
-- If you do not want signature verification, omit `publicKeyMap` in `startWorker`.
 - Pass `undefined` as the private key to `submitJob` to send unsigned envelopes.

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -17,12 +17,17 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
+        "@types/node": "18.19.130",
         "chai": "^6.2.1",
         "mocha": "^11.7.5",
+        "publint": "0.3.21",
         "ts-mocha": "^11.1.0",
         "tsconfig-paths": "^4.2.0",
         "typedoc": "^0.28.17",
         "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -175,6 +180,22 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.5.tgz",
+      "integrity": "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyexec": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
     },
     "node_modules/@redis/bloom": {
       "version": "1.2.0",
@@ -352,12 +373,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/unist": {
@@ -1159,6 +1180,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1229,6 +1260,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1297,6 +1335,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/publint": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz",
+      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.4",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -1356,6 +1416,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-buffer": {
@@ -1568,6 +1641,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-11.1.0.tgz",
@@ -1703,9 +1786,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -2,6 +2,7 @@
   "name": "cap-sdk-node",
   "version": "2.5.3",
   "description": "CAP (Cordum Agent Protocol) SDK for Node/TypeScript",
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -13,12 +14,15 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cordum-io/cap.git",
+    "url": "git+https://github.com/cordum-io/cap.git",
     "directory": "sdk/node"
   },
   "homepage": "https://github.com/cordum-io/cap#readme",
   "bugs": {
     "url": "https://github.com/cordum-io/cap/issues"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "keywords": [
     "cap",
@@ -29,10 +33,13 @@
     "ai"
   ],
   "scripts": {
-    "build": "tsc -p .",
-    "lint": "echo \"add linter\"",
+    "build": "node scripts/build-package.cjs",
+    "lint": "npm run lint:package",
+    "lint:package": "publint --pack false --level error",
     "sample:worker": "node dist/sample-worker.js",
-    "test": "tsc -p tsconfig.test.json --outDir dist && mocha dist/test/*.test.js",
+    "test": "node -e \"require('fs').rmSync('.build',{recursive:true,force:true})\" && tsc -p tsconfig.test.json && mocha \".build/test/*.test.js\"",
+    "test:nats": "node -e \"require('fs').rmSync('.build',{recursive:true,force:true})\" && tsc -p tsconfig.test.json && mocha \".build/test/integration/nats.e2e.js\"",
+    "test:package": "node scripts/verify-package.cjs",
     "docs": "typedoc --out docs src/index.ts"
   },
   "dependencies": {
@@ -44,8 +51,10 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
+    "@types/node": "18.19.130",
     "chai": "^6.2.1",
     "mocha": "^11.7.5",
+    "publint": "0.3.21",
     "ts-mocha": "^11.1.0",
     "tsconfig-paths": "^4.2.0",
     "typedoc": "^0.28.17",

--- a/sdk/node/scripts/build-package.cjs
+++ b/sdk/node/scripts/build-package.cjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const SDK_ROOT = path.resolve(__dirname, "..");
+const DIST_DIR = path.join(SDK_ROOT, "dist");
+const PROTO_NAMES = [
+  "alert.proto",
+  "buspacket.proto",
+  "handshake.proto",
+  "heartbeat.proto",
+  "job.proto",
+  "policy.proto",
+  "safety.proto",
+];
+
+function compileSource() {
+  const tsc = path.join(SDK_ROOT, "node_modules", "typescript", "bin", "tsc");
+  assert.equal(fs.existsSync(tsc), true, "run npm ci before building the package");
+  const result = spawnSync(process.execPath, [tsc, "--project", "tsconfig.json"], {
+    cwd: SDK_ROOT,
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    fs.rmSync(DIST_DIR, { recursive: true, force: true });
+    throw new Error(`TypeScript build failed (${result.status})\n${output}`);
+  }
+}
+
+function copyCanonicalProtos() {
+  const sourceDir = path.resolve(SDK_ROOT, "..", "..", "proto", "cordum", "agent", "v1");
+  const actual = fs
+    .readdirSync(sourceDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".proto"))
+    .map((entry) => entry.name)
+    .sort();
+  assert.deepEqual(actual, [...PROTO_NAMES].sort(), "canonical CAP proto set changed");
+
+  const destinationDir = path.join(DIST_DIR, "proto", "cordum", "agent", "v1");
+  fs.mkdirSync(destinationDir, { recursive: true });
+  for (const name of PROTO_NAMES) {
+    fs.copyFileSync(path.join(sourceDir, name), path.join(destinationDir, name));
+  }
+}
+
+function main() {
+  fs.rmSync(DIST_DIR, { recursive: true, force: true });
+  compileSource();
+  copyCanonicalProtos();
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+}

--- a/sdk/node/scripts/verify-package.cjs
+++ b/sdk/node/scripts/verify-package.cjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const SDK_ROOT = path.resolve(__dirname, "..");
+const EXPECTED_PROTOS = [
+  "alert.proto",
+  "buspacket.proto",
+  "handshake.proto",
+  "heartbeat.proto",
+  "job.proto",
+  "policy.proto",
+  "safety.proto",
+].map((name) => `dist/proto/cordum/agent/v1/${name}`);
+
+function run(command, args, cwd = SDK_ROOT) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    shell: false,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(`${command} ${args.join(" ")} failed (${result.status})\n${output}`);
+  }
+  return result.stdout.trim();
+}
+
+function runNpm(args, cwd = SDK_ROOT) {
+  if (process.platform !== "win32") {
+    return run("npm", args, cwd);
+  }
+  const npmCli =
+    process.env.npm_execpath ??
+    path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+  assert.equal(fs.existsSync(npmCli), true, `cannot locate npm CLI: ${npmCli}`);
+  return run(process.execPath, [npmCli, ...args], cwd);
+}
+
+function packSdk(tempDir) {
+  fs.rmSync(path.join(SDK_ROOT, "dist"), { recursive: true, force: true });
+  fs.rmSync(path.join(SDK_ROOT, ".build"), { recursive: true, force: true });
+  runNpm(["run", "build"]);
+
+  const packDir = path.join(tempDir, "package");
+  fs.mkdirSync(packDir, { recursive: true });
+  const output = runNpm(["pack", "--json", "--pack-destination", packDir]);
+  const entry = parsePackEntry(output, "npm pack output");
+  const tarball = path.join(packDir, entry.filename);
+  assert.equal(fs.existsSync(tarball), true, `missing packed tarball: ${tarball}`);
+  verifyTarballMetadata(entry, tarball);
+  return { entry, tarball };
+}
+
+function parsePackEntry(json, source) {
+  const entries = JSON.parse(json);
+  assert.equal(Array.isArray(entries), true, `${source} must be a JSON array`);
+  assert.equal(entries.length, 1, `${source} must describe exactly one tarball`);
+  const [entry] = entries;
+  assert.equal(typeof entry?.filename, "string", `${source} lacks filename`);
+  assert.equal(Array.isArray(entry.files), true, `${source} lacks files`);
+  return entry;
+}
+
+function verifyTarballMetadata(entry, tarball) {
+  assert.equal(path.basename(tarball), entry.filename, "tarball filename differs from pack JSON");
+  const bytes = fs.readFileSync(tarball);
+  if (typeof entry.size === "number") {
+    assert.equal(bytes.length, entry.size, "tarball size differs from pack JSON");
+  }
+  if (typeof entry.integrity === "string") {
+    const integrity = `sha512-${crypto.createHash("sha512").update(bytes).digest("base64")}`;
+    assert.equal(integrity, entry.integrity, "tarball integrity differs from pack JSON");
+  }
+  if (typeof entry.shasum === "string") {
+    const shasum = crypto.createHash("sha1").update(bytes).digest("hex");
+    assert.equal(shasum, entry.shasum, "tarball shasum differs from pack JSON");
+  }
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    assert.ok(value, `missing value for ${flag ?? "argument"}`);
+    if (flag === "--tarball") options.tarball = value;
+    else if (flag === "--pack-json") options.packJson = value;
+    else throw new Error(`unknown argument: ${flag}`);
+  }
+  const supplied = Boolean(options.tarball || options.packJson);
+  assert.equal(
+    supplied && Boolean(options.tarball) === Boolean(options.packJson),
+    supplied,
+    "--tarball and --pack-json must be supplied together",
+  );
+  return options;
+}
+
+function suppliedArtifact(options) {
+  const tarball = path.resolve(options.tarball);
+  const packJson = path.resolve(options.packJson);
+  assert.equal(fs.existsSync(tarball), true, `missing supplied tarball: ${tarball}`);
+  assert.equal(fs.existsSync(packJson), true, `missing supplied pack JSON: ${packJson}`);
+  const entry = parsePackEntry(fs.readFileSync(packJson, "utf8"), "supplied pack JSON");
+  verifyTarballMetadata(entry, tarball);
+  return { entry, tarball };
+}
+
+function verifyManifest(entry) {
+  const files = entry.files.map((file) => file.path.replaceAll("\\", "/"));
+  const protos = files.filter((file) => file.endsWith(".proto")).sort();
+  const forbidden = files.filter(
+    (file) =>
+      file.startsWith("dist/src/") ||
+      file.startsWith("dist/test/") ||
+      file.startsWith(".build/") ||
+      /(^|\/)sample-worker(?:\.|\/)/.test(file),
+  );
+  const failures = [];
+  if (!files.includes("LICENSE")) {
+    failures.push("missing LICENSE");
+  }
+  if (JSON.stringify(protos) !== JSON.stringify([...EXPECTED_PROTOS].sort())) {
+    failures.push(`expected exactly seven bundled protos; found: ${protos.join(", ") || "none"}`);
+  }
+  if (forbidden.length > 0) {
+    failures.push(`forbidden build/test/sample files: ${forbidden.join(", ")}`);
+  }
+  assert.deepEqual(failures, [], `invalid npm artifact:\n- ${failures.join("\n- ")}`);
+}
+
+function verifyPublint(tarball) {
+  const cli = path.join(SDK_ROOT, "node_modules", "publint", "src", "cli.js");
+  assert.equal(fs.existsSync(cli), true, `cannot locate publint CLI: ${cli}`);
+  const output = run(process.execPath, [cli, tarball, "--strict"]);
+  if (output) console.log(output);
+}
+
+function writeConsumer(consumerDir) {
+  const files = {
+    "package.json": JSON.stringify({ name: "cap-package-consumer", private: true, type: "module" }),
+    "cjs-probe.cjs": `
+const assert = require("node:assert/strict");
+const sdk = require("cap-sdk-node");
+(async () => {
+  assert.equal(typeof sdk.loadRoot, "function");
+  const packet = (await sdk.loadRoot()).lookupType("cordum.agent.v1.BusPacket");
+  assert.equal(packet.fullName, ".cordum.agent.v1.BusPacket");
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+`,
+    "esm-probe.mjs": `
+import assert from "node:assert/strict";
+import { loadRoot } from "cap-sdk-node";
+assert.equal(typeof loadRoot, "function");
+const packet = (await loadRoot()).lookupType("cordum.agent.v1.BusPacket");
+assert.equal(packet.fullName, ".cordum.agent.v1.BusPacket");
+`,
+    "consumer.ts": `
+import { loadRoot, SUBJECT_SUBMIT } from "cap-sdk-node";
+async function describePacket(): Promise<string> {
+  const packet = (await loadRoot()).lookupType("cordum.agent.v1.BusPacket");
+  return \`${"${SUBJECT_SUBMIT}"}:${"${packet.fullName}"}\`;
+}
+void describePacket();
+`,
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        lib: ["DOM", "ES2020"],
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        noEmit: true,
+        skipLibCheck: false,
+        strict: true,
+        target: "ES2020",
+        types: ["node"],
+      },
+      include: ["consumer.ts"],
+    }),
+  };
+  fs.mkdirSync(consumerDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(consumerDir, name), `${content.trim()}\n`);
+  }
+}
+
+function verifyConsumer(tarball, tempDir) {
+  const consumerDir = path.join(tempDir, "consumer");
+  writeConsumer(consumerDir);
+  runNpm(
+    ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false", tarball],
+    consumerDir,
+  );
+  const typescriptVersion = require(path.join(
+    SDK_ROOT,
+    "node_modules",
+    "typescript",
+    "package.json",
+  )).version;
+  const nodeTypesVersion = require(path.join(
+    SDK_ROOT,
+    "node_modules",
+    "@types",
+    "node",
+    "package.json",
+  )).version;
+  runNpm(
+    [
+      "install",
+      "--save-dev",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--package-lock=false",
+      `typescript@${typescriptVersion}`,
+      `@types/node@${nodeTypesVersion}`,
+    ],
+    consumerDir,
+  );
+  run(process.execPath, ["cjs-probe.cjs"], consumerDir);
+  run(process.execPath, ["esm-probe.mjs"], consumerDir);
+
+  const tsc = path.join(consumerDir, "node_modules", "typescript", "bin", "tsc");
+  run(process.execPath, [tsc, "--project", "tsconfig.json"], consumerDir);
+}
+
+function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cap-node-package-"));
+  try {
+    const artifact = options.tarball ? suppliedArtifact(options) : packSdk(tempDir);
+    const { entry, tarball } = artifact;
+    verifyManifest(entry);
+    verifyPublint(tarball);
+    verifyConsumer(tarball, tempDir);
+    console.log(`package verification passed: ${entry.filename}`);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+}

--- a/sdk/node/src/protos.ts
+++ b/sdk/node/src/protos.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 
 const PROTO_DIR_CANDIDATES = [
+  path.resolve(__dirname, "proto"),
   path.resolve(__dirname, "..", "..", "..", "proto"),
   path.resolve(__dirname, "..", "..", "..", "..", "proto"),
 ];

--- a/sdk/node/src/runtime.ts
+++ b/sdk/node/src/runtime.ts
@@ -1,4 +1,9 @@
-import { connect, NatsConnection } from "nats";
+import {
+  connect,
+  NatsConnection,
+  Subscription,
+  SubscriptionOptions,
+} from "nats";
 import { createClient, RedisClientType } from "redis";
 import { z, ZodTypeAny } from "zod";
 import { encodeDeterministic, encodeUnsignedForSignature } from "./codec";
@@ -6,11 +11,12 @@ import { loadRoot, SUBJECT_RESULT, DEFAULT_PROTOCOL_VERSION } from "./protos";
 import type { Middleware } from "./middleware";
 import * as crypto from "crypto";
 import { heartbeatLoop, heartbeatPayload } from "./heartbeat";
-import { MalformedPacketError, SignatureInvalidError, SignatureMissingError, InvalidInputError } from "./errors";
+import { MalformedPacketError, InvalidInputError } from "./errors";
 import type { Logger } from "./logger";
 import type { MetricsHook } from "./metrics";
 import { noopMetrics } from "./metrics";
 import { handshakePayload, publishHandshake } from "./handshake";
+import { verifyInboundPacket } from "./security";
 
 export type { Logger } from "./logger";
 
@@ -18,6 +24,8 @@ const DEFAULT_NATS_URL = "nats://127.0.0.1:4222";
 const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379/0";
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
+
+class OperationTimeoutError extends Error {}
 
 /** Abstraction over payload storage (Redis, in-memory, etc.). */
 export interface BlobStore {
@@ -95,6 +103,8 @@ interface HandlerSpec {
   retries: number;
 }
 
+type AgentState = "idle" | "starting" | "running" | "closing" | "closed";
+
 /** Options for constructing an {@link Agent}. */
 export interface AgentOptions {
   natsUrl?: string;
@@ -160,7 +170,7 @@ async function withTimeout<T>(promise: Promise<T>, ms: number | undefined, label
     return promise;
   }
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+    const timer = setTimeout(() => reject(new OperationTimeoutError(`${label} timed out`)), ms);
     promise
       .then((value) => {
         clearTimeout(timer);
@@ -202,6 +212,11 @@ export class Agent {
   private jobResultType?: any;
   private heartbeatHandle?: { stop: () => void };
   private activeJobCount = 0;
+  private readonly subscriptions: Subscription[] = [];
+  private readonly inFlight = new Set<Promise<void>>();
+  private state: AgentState = "idle";
+  private startPromise?: Promise<void>;
+  private closePromise?: Promise<void>;
 
   constructor(options: AgentOptions = {}) {
     this.natsUrl = options.natsUrl ?? process.env.NATS_URL ?? DEFAULT_NATS_URL;
@@ -285,60 +300,137 @@ export class Agent {
     if (this.handlers.size === 0) {
       throw new Error("no handlers registered");
     }
-    this.nc = await withTimeout(
-      this.connectFn({ servers: this.natsUrl, name: this.senderId }),
-      this.ioTimeoutMs,
-      "nats connect"
-    );
+    if (this.state !== "idle") {
+      throw new Error(`Agent already started or closed (state: ${this.state})`);
+    }
+    this.state = "starting";
+    this.startPromise = this.startInternal();
+    return this.startPromise;
+  }
+
+  async close(): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeInternal();
+    }
+    return this.closePromise;
+  }
+
+  private async startInternal(): Promise<void> {
+    try {
+      await this.initializeRuntime();
+      await this.publishStartupHandshake();
+      this.startHeartbeat();
+      this.state = "running";
+    } catch (error) {
+      try {
+        await this.closeResources();
+      } catch (cleanupError) {
+        this.logger.error("Agent start cleanup failed", {
+          error: String(cleanupError),
+        });
+      }
+      this.state = "closed";
+      throw error;
+    }
+  }
+
+  private async initializeRuntime(): Promise<void> {
+    const connection = await this.connectRuntime();
+    this.nc = connection;
     if (!this.store) {
       this.store = new RedisBlobStore(this.redisUrl);
     }
-
     const root = await loadRoot();
     this.busPacketType = root.lookupType("cordum.agent.v1.BusPacket");
     this.jobResultType = root.lookupType("cordum.agent.v1.JobResult");
-
     for (const spec of this.handlers.values()) {
-      (this.nc as any).subscribe(
-        spec.topic,
-        { queue: spec.topic },
-        (...args: any[]) => {
-          let err: Error | null = null;
-          let msg: any;
-          if (args.length >= 2) {
-            err = args[0] as Error | null;
-            msg = args[1];
-          } else {
-            msg = args[0];
-          }
-          if (err) {
-            this.logger.error("subscribe error", { error: String(err) });
-            return;
-          }
-          if (!msg) {
-            return;
-          }
-          void this.onMessage(msg, spec);
-        }
-      );
+      this.subscriptions.push(this.subscribe(connection, spec));
     }
+  }
 
+  private async connectRuntime(): Promise<NatsConnection> {
+    const pending = this.connectFn({ servers: this.natsUrl, name: this.senderId });
+    try {
+      return await withTimeout(pending, this.ioTimeoutMs, "nats connect");
+    } catch (error) {
+      if (error instanceof OperationTimeoutError) {
+        void pending.then(
+          (connection) => this.closeLateConnection(connection),
+          () => undefined
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async closeLateConnection(connection: NatsConnection): Promise<void> {
+    try {
+      await connection.close();
+    } catch (error) {
+      this.logger.warn("late NATS connection cleanup failed", { error: String(error) });
+    }
+  }
+
+  private subscribe(connection: NatsConnection, spec: HandlerSpec): Subscription {
+    const options: SubscriptionOptions = {
+      queue: spec.topic,
+      callback: (error, msg) => {
+        if (error) {
+          this.logger.error("subscribe error", { error: String(error) });
+          return;
+        }
+        this.trackMessage(this.onMessage(msg, spec));
+      },
+    };
+    return connection.subscribe(spec.topic, options);
+  }
+
+  private trackMessage(work: Promise<void>): void {
+    const tracked = work
+      .catch((error: unknown) => {
+        this.logger.error("message processing failed", { error: String(error) });
+      })
+      .finally(() => this.inFlight.delete(tracked));
+    this.inFlight.add(tracked);
+  }
+
+  private async publishStartupHandshake(): Promise<void> {
+    if (!this.nc) {
+      throw new Error("NATS not initialized");
+    }
     try {
       const readyTopics = Array.from(this.handlers.keys()).sort();
+      const capabilities = Object.fromEntries(
+        Array.from(this.handlers.keys(), (topic) => [topic, true])
+      );
       const packet = await handshakePayload(
         this.senderId,
-        Object.fromEntries(Array.from(this.handlers.keys(), (topic) => [topic, true])),
+        capabilities,
         this.senderId,
         readyTopics
       );
       await publishHandshake(this.nc, packet, this.privateKey);
-    } catch (err) {
-      this.logger.warn("handshake publish failed", { senderId: this.senderId, error: String(err) });
+    } catch (error) {
+      this.logger.warn("handshake publish failed", {
+        senderId: this.senderId,
+        error: String(error),
+      });
     }
+  }
 
+  private startHeartbeat(): void {
+    if (!this.nc) {
+      throw new Error("NATS not initialized");
+    }
     this.heartbeatHandle = heartbeatLoop(
       this.nc,
-      () => heartbeatPayload(this.senderId, this.pool, this.activeJobCount, this.maxParallel, 0),
+      () => heartbeatPayload(
+        this.senderId,
+        this.pool,
+        this.activeJobCount,
+        this.maxParallel,
+        0
+      ),
       {
         interval: this.heartbeatInterval,
         privateKey: this.privateKey,
@@ -348,14 +440,54 @@ export class Agent {
     );
   }
 
-  async close(): Promise<void> {
+  private async closeInternal(): Promise<void> {
+    if (this.state === "starting" && this.startPromise) {
+      try {
+        await this.startPromise;
+      } catch {
+        return;
+      }
+    }
+    if (this.state === "closed") {
+      return;
+    }
+    this.state = "closing";
+    try {
+      await this.closeResources();
+    } finally {
+      this.state = "closed";
+    }
+  }
+
+  private async closeResources(): Promise<void> {
     this.heartbeatHandle?.stop();
     this.heartbeatHandle = undefined;
-    if (this.nc) {
-      await this.nc.drain();
+    const subscriptions = this.subscriptions.splice(0);
+    await Promise.all(subscriptions.map((subscription) => this.drainSubscription(subscription)));
+    while (this.inFlight.size > 0) {
+      await Promise.all([...this.inFlight]);
     }
-    if (this.store) {
-      await this.store.close();
+    const connection = this.nc;
+    try {
+      if (connection) {
+        await connection.drain();
+      }
+    } finally {
+      this.nc = undefined;
+      const store = this.store;
+      this.store = undefined;
+      if (store) {
+        await store.close();
+      }
+    }
+  }
+
+  private async drainSubscription(subscription: Subscription): Promise<void> {
+    try {
+      await subscription.drain();
+    } catch (error) {
+      this.logger.warn("subscription drain failed", { error: String(error) });
+      subscription.unsubscribe();
     }
   }
 
@@ -383,24 +515,11 @@ export class Agent {
       return;
     }
 
-    if (this.publicKeyMap) {
-      const senderId = packet.senderId;
-      const signature = packet.signature;
-      if (!senderId || !this.publicKeyMap[senderId]) {
-        this.logger.warn("no public key for sender", { senderId });
-        return;
-      }
-      if (!signature || signature.length === 0) {
-        this.logger.warn("missing signature", { senderId, error: new SignatureMissingError(`sender ${senderId}`).message });
-        return;
-      }
-      const unsignedData = encodeUnsignedForSignature(this.busPacketType, packet);
-      const verify = crypto.createVerify("sha256");
-      verify.update(unsignedData);
-      if (!verify.verify(this.publicKeyMap[senderId], signature)) {
-        this.logger.warn("invalid signature", { senderId, error: new SignatureInvalidError(`sender ${senderId}`).message });
-        return;
-      }
+    try {
+      verifyInboundPacket(this.busPacketType, packet, this.publicKeyMap);
+    } catch (error) {
+      this.logger.warn("Agent rejected inbound packet", { error: String(error) });
+      return;
     }
 
     const req = packet.jobRequest;

--- a/sdk/node/src/runtime.ts
+++ b/sdk/node/src/runtime.ts
@@ -470,7 +470,12 @@ export class Agent {
     const connection = this.nc;
     try {
       if (connection) {
-        await connection.drain();
+        try {
+          await withTimeout(connection.drain(), this.ioTimeoutMs, "nats drain");
+        } catch (error) {
+          this.logger.warn("connection drain failed", { error: String(error) });
+          await connection.close();
+        }
       }
     } finally {
       this.nc = undefined;
@@ -484,10 +489,16 @@ export class Agent {
 
   private async drainSubscription(subscription: Subscription): Promise<void> {
     try {
-      await subscription.drain();
+      await withTimeout(subscription.drain(), this.ioTimeoutMs, "subscription drain");
     } catch (error) {
       this.logger.warn("subscription drain failed", { error: String(error) });
-      subscription.unsubscribe();
+      try {
+        subscription.unsubscribe();
+      } catch (unsubscribeError) {
+        this.logger.warn("subscription unsubscribe failed", {
+          error: String(unsubscribeError),
+        });
+      }
     }
   }
 

--- a/sdk/node/src/security.ts
+++ b/sdk/node/src/security.ts
@@ -1,0 +1,84 @@
+import * as crypto from "node:crypto";
+import type { Type } from "protobufjs";
+import { encodeUnsignedForSignature } from "./codec";
+import {
+  MalformedPacketError,
+  SignatureInvalidError,
+  SignatureMissingError,
+} from "./errors";
+import { validateBusPacket } from "./validate";
+
+interface InboundPacket {
+  senderId?: unknown;
+  signature?: unknown;
+}
+
+/** Validates an inbound envelope and enforces signature policy when configured. */
+export function verifyInboundPacket(
+  packetType: Type,
+  packet: unknown,
+  publicKeyMap: Readonly<Record<string, string>> | undefined
+): void {
+  const validationErrors = validateBusPacket(packet);
+  if (validationErrors.length > 0) {
+    const details = validationErrors
+      .slice(0, 8)
+      .map(({ field, message }) => `${field}: ${message}`)
+      .join("; ");
+    throw new MalformedPacketError(details);
+  }
+  if (publicKeyMap === undefined) {
+    return;
+  }
+
+  const view = packet as InboundPacket;
+  const senderId = requireSender(view.senderId);
+  const signature = requireSignature(view.signature);
+  const publicKey = lookupPublicKey(publicKeyMap, senderId);
+  if (!verifySignature(packetType, packet, publicKey, signature)) {
+    throw new SignatureInvalidError("inbound signature verification failed");
+  }
+}
+
+function requireSender(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new SignatureInvalidError("authenticated sender identity is required");
+  }
+  return value;
+}
+
+function requireSignature(value: unknown): Uint8Array {
+  if (!(value instanceof Uint8Array) || value.length === 0) {
+    throw new SignatureMissingError("inbound signature is required");
+  }
+  return value;
+}
+
+function lookupPublicKey(
+  publicKeyMap: Readonly<Record<string, string>>,
+  senderId: string
+): string {
+  if (!Object.prototype.hasOwnProperty.call(publicKeyMap, senderId)) {
+    throw new SignatureInvalidError("no trusted public key for sender");
+  }
+  const publicKey = publicKeyMap[senderId];
+  if (typeof publicKey !== "string" || publicKey.trim().length === 0) {
+    throw new SignatureInvalidError("trusted public key is invalid");
+  }
+  return publicKey;
+}
+
+function verifySignature(
+  packetType: Type,
+  packet: unknown,
+  publicKey: string,
+  signature: Uint8Array
+): boolean {
+  try {
+    const verifier = crypto.createVerify("sha256");
+    verifier.update(encodeUnsignedForSignature(packetType, packet));
+    return verifier.verify(publicKey, signature);
+  } catch {
+    throw new SignatureInvalidError("trusted public key is invalid");
+  }
+}

--- a/sdk/node/src/security.ts
+++ b/sdk/node/src/security.ts
@@ -74,11 +74,28 @@ function verifySignature(
   publicKey: string,
   signature: Uint8Array
 ): boolean {
+  const key = requireP256PublicKey(publicKey);
   try {
     const verifier = crypto.createVerify("sha256");
     verifier.update(encodeUnsignedForSignature(packetType, packet));
-    return verifier.verify(publicKey, signature);
+    return verifier.verify(key, signature);
   } catch {
     throw new SignatureInvalidError("trusted public key is invalid");
   }
+}
+
+function requireP256PublicKey(publicKey: string): crypto.KeyObject {
+  let key: crypto.KeyObject;
+  try {
+    key = crypto.createPublicKey(publicKey);
+  } catch {
+    throw new SignatureInvalidError("trusted public key is invalid");
+  }
+  if (
+    key.asymmetricKeyType !== "ec" ||
+    key.asymmetricKeyDetails?.namedCurve !== "prime256v1"
+  ) {
+    throw new SignatureInvalidError("trusted public key must use ECDSA P-256");
+  }
+  return key;
 }

--- a/sdk/node/src/testing.ts
+++ b/sdk/node/src/testing.ts
@@ -2,7 +2,8 @@
  * Testing utilities for CAP Node SDK.
  * Allows testing handlers without running NATS or Redis.
  */
-import { z, ZodTypeAny } from "zod";
+import type { Msg, NatsConnection, Subscription, SubscriptionOptions } from "nats";
+import { z } from "zod";
 import { Agent, InMemoryBlobStore, AgentOptions, Context } from "./runtime";
 import { loadRoot, DEFAULT_PROTOCOL_VERSION } from "./protos";
 import { encodeDeterministic } from "./codec";
@@ -19,17 +20,31 @@ export interface PublishedMsg {
  */
 export class MockNatsConnection {
   published: PublishedMsg[] = [];
-  subscriptions: Map<string, (msg: any) => void> = new Map();
+  subscriptions: Map<
+    string,
+    NonNullable<SubscriptionOptions["callback"]>
+  > = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this.published.push({ subject, data });
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: any) => void): any {
-    if (cb) {
-      this.subscriptions.set(subject, cb);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this.subscriptions.set(subject, opts.callback);
     }
-    return { drain: async () => {} };
+    return {
+      drain: async () => {},
+      unsubscribe: () => {},
+    } as unknown as Subscription;
+  }
+
+  deliver(subject: string, data: Uint8Array): void {
+    const callback = this.subscriptions.get(subject);
+    if (!callback) {
+      throw new Error(`no callback subscription found for subject ${subject}`);
+    }
+    callback(null, { subject, data } as unknown as Msg);
   }
 
   async drain(): Promise<void> {
@@ -48,7 +63,7 @@ export function createTestAgent(
   const store = new InMemoryBlobStore();
   const agent = new Agent({
     store,
-    connectFn: async () => bus as any,
+    connectFn: async () => bus as unknown as NatsConnection,
     senderId: options.senderId ?? "test-worker",
     retries: options.retries ?? 0,
     ...options,
@@ -97,12 +112,12 @@ export async function testHandler<TIn, TOut>(
   const jobId = options.jobId ?? "test-job-1";
 
   if (options.inputSchema) {
-    agent.job(topic, options.inputSchema, handler as any, {
-      outputSchema: options.outputSchema as any,
+    agent.job<TIn, TOut>(topic, options.inputSchema, handler, {
+      outputSchema: options.outputSchema,
     });
   } else {
-    agent.job(topic, handler as any, {
-      outputSchema: options.outputSchema as any,
+    agent.job<TIn, TOut>(topic, handler, {
+      outputSchema: options.outputSchema,
     });
   }
 
@@ -118,21 +133,23 @@ export async function testHandler<TIn, TOut>(
     traceId: "test-trace",
     senderId: "test-client",
     protocolVersion: DEFAULT_PROTOCOL_VERSION,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
     jobRequest: { jobId, topic, contextPtr: `redis://${ctxKey}` },
   });
   const payload = encodeDeterministic(BusPacket, packet);
 
   const initialCount = bus.published.length;
-  const cb = bus.subscriptions.get(topic);
-  if (!cb) {
-    throw new Error(`no subscription found for topic ${topic}`);
-  }
-  cb({ data: payload });
+  bus.deliver(topic, payload);
 
   await waitForPublish(bus, initialCount);
 
-  const resultPacket = BusPacket.decode(bus.published[bus.published.length - 1].data) as any;
+  const resultPacket = BusPacket.decode(
+    bus.published[bus.published.length - 1].data
+  ) as unknown as { jobResult?: JobResultView };
   const jr = resultPacket.jobResult;
+  if (!jr) {
+    throw new Error("worker did not publish a JobResult");
+  }
 
   await agent.close();
 
@@ -143,4 +160,12 @@ export async function testHandler<TIn, TOut>(
     errorMessage: jr.errorMessage ?? "",
     workerId: jr.workerId ?? "",
   };
+}
+
+interface JobResultView {
+  status: number;
+  jobId: string;
+  resultPtr?: string;
+  errorMessage?: string;
+  workerId?: string;
 }

--- a/sdk/node/src/worker.ts
+++ b/sdk/node/src/worker.ts
@@ -1,11 +1,17 @@
-import { NatsConnection, Subscription } from "nats";
+import type {
+  Msg,
+  NatsConnection,
+  Subscription,
+  SubscriptionOptions,
+} from "nats";
+import type { Type } from "protobufjs";
 import { loadRoot, SUBJECT_RESULT, DEFAULT_PROTOCOL_VERSION } from "./protos";
 import { encodeDeterministic, encodeUnsignedForSignature } from "./codec";
 import type { Logger } from "./logger";
 import type { MetricsHook } from "./metrics";
 import { noopMetrics } from "./metrics";
 import * as crypto from "crypto";
-import { MalformedPacketError, SignatureInvalidError, SignatureMissingError } from "./errors";
+import { verifyInboundPacket } from "./security";
 
 /** Callback that processes a decoded JobRequest and returns a JobResult. */
 type Handler = (jobRequest: any) => Promise<any>;
@@ -28,6 +34,25 @@ export interface WorkerConfig {
   metrics?: MetricsHook;
 }
 
+interface JobRequestView {
+  jobId?: string;
+  topic?: string;
+}
+
+interface PacketView {
+  traceId?: string;
+  jobRequest?: JobRequestView;
+}
+
+interface SignablePacket {
+  signature?: Uint8Array;
+}
+
+interface WorkerTypes {
+  busPacket: Type;
+  jobResult: Type;
+}
+
 /**
  * Subscribes to a NATS subject and dispatches incoming JobRequests to the handler.
  *
@@ -38,103 +63,124 @@ export interface WorkerConfig {
  */
 export async function startWorker(cfg: WorkerConfig): Promise<Subscription> {
   const root = await loadRoot();
-  const BusPacket = root.lookupType("cordum.agent.v1.BusPacket");
-  const JobResult = root.lookupType("cordum.agent.v1.JobResult");
+  const types: WorkerTypes = {
+    busPacket: root.lookupType("cordum.agent.v1.BusPacket"),
+    jobResult: root.lookupType("cordum.agent.v1.JobResult"),
+  };
   const logger: Logger = cfg.logger ?? console;
   const metrics: MetricsHook = cfg.metrics ?? noopMetrics;
-
-  const onMessage = async (msg: any) => {
-    try {
-      const packet = BusPacket.decode(msg.data) as any;
-
-      // Signature verification
-      if (cfg.publicKeyMap && packet.senderId && packet.signature && packet.signature.length > 0) {
-        const publicKey = cfg.publicKeyMap[packet.senderId];
-        if (!publicKey) {
-          logger.warn("no public key found", { senderId: packet.senderId });
-          return;
-        }
-
-        const receivedSignature = packet.signature;
-        const unsignedData = encodeUnsignedForSignature(BusPacket, packet);
-
-        const verify = crypto.createVerify("sha256");
-        verify.update(unsignedData);
-        if (!verify.verify(publicKey, receivedSignature)) {
-          logger.warn("invalid signature", { senderId: packet.senderId, error: new SignatureInvalidError(`sender ${packet.senderId}`).message });
-          return;
-        }
-      } else if (cfg.publicKeyMap && (!packet.signature || packet.signature.length === 0)) {
-        logger.warn("missing signature", { senderId: packet.senderId, error: new SignatureMissingError(`sender ${packet.senderId}`).message });
-        return;
-      }
-
-      const jr = packet.jobRequest;
-      if (!jr) return;
-      metrics.onJobReceived(jr.jobId, jr.topic);
-      const startTime = Date.now();
-      // Apply middleware chain
-      let wrappedHandler = cfg.handler;
-      if (cfg.middlewares) {
-        for (let i = cfg.middlewares.length - 1; i >= 0; i--) {
-          wrappedHandler = cfg.middlewares[i](wrappedHandler);
-        }
-      }
-      let resObj: any;
-      try {
-        resObj = await wrappedHandler(jr);
-      } catch (err) {
-        resObj = {
-          jobId: jr.jobId,
-          status: "JOB_STATUS_FAILED",
-          errorMessage: err instanceof Error ? err.message : String(err),
-        };
-      }
-      if (!resObj) {
-        resObj = {
-          jobId: jr.jobId,
-          status: "JOB_STATUS_FAILED",
-          errorMessage: "handler returned null",
-        };
-      }
-      if (!resObj.jobId) {
-        resObj.jobId = jr.jobId;
-      }
-      if (!resObj.workerId) {
-        resObj.workerId = cfg.senderId;
-      }
-
-      const elapsedMs = Date.now() - startTime;
-      if (resObj.status === "JOB_STATUS_FAILED") {
-        metrics.onJobFailed(resObj.jobId, resObj.errorMessage ?? "");
-      } else {
-        metrics.onJobCompleted(resObj.jobId, elapsedMs, resObj.status ?? "JOB_STATUS_SUCCEEDED");
-      }
-
-      const jrMsg = JobResult.fromObject(resObj);
-      const out = BusPacket.fromObject({
-        traceId: packet.traceId,
-        senderId: cfg.senderId,
-        protocolVersion: DEFAULT_PROTOCOL_VERSION,
-        createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
-        jobResult: jrMsg,
-      }) as any;
-
-      // Signing outgoing packet
-      if (cfg.privateKey) {
-        const unsignedOutData = encodeUnsignedForSignature(BusPacket, out);
-        const sign = crypto.createSign("sha256");
-        sign.update(unsignedOutData);
-        out.signature = sign.sign(cfg.privateKey);
-      }
-
-      const data = encodeDeterministic(BusPacket, out);
-      await cfg.nc.publish(SUBJECT_RESULT, data);
-    } catch (err) {
-      logger.error("worker error", { error: String(err) });
+  const callback: NonNullable<SubscriptionOptions["callback"]> = (error, msg) => {
+    if (error) {
+      logger.error("worker subscription error", { error: String(error) });
+      return;
     }
+    void processWorkerMessage(cfg, types, logger, metrics, msg).catch((processingError) => {
+      logger.error("worker message processing failed", {
+        error: String(processingError),
+      });
+    });
   };
+  return cfg.nc.subscribe(cfg.subject, {
+    queue: cfg.queue ?? cfg.subject,
+    callback,
+  });
+}
 
-  const sub: any = (cfg.nc as any).subscribe(cfg.subject, { queue: cfg.queue ?? cfg.subject }, onMessage);
-  return sub;
+async function processWorkerMessage(
+  cfg: WorkerConfig,
+  types: WorkerTypes,
+  logger: Logger,
+  metrics: MetricsHook,
+  msg: Msg
+): Promise<void> {
+  const packet = types.busPacket.decode(msg.data) as unknown as PacketView;
+  try {
+    verifyInboundPacket(types.busPacket, packet, cfg.publicKeyMap);
+  } catch (error) {
+    logger.warn("worker rejected inbound packet", { error: String(error) });
+    return;
+  }
+  const request = packet.jobRequest;
+  if (!request) return;
+  metrics.onJobReceived(request.jobId ?? "", request.topic ?? "");
+  const startedAt = Date.now();
+  const result = await executeHandler(cfg, request);
+  const elapsedMs = Date.now() - startedAt;
+  recordResultMetrics(metrics, result, elapsedMs);
+  await publishWorkerResult(cfg, types, packet, result);
+}
+
+async function executeHandler(
+  cfg: WorkerConfig,
+  request: JobRequestView
+): Promise<Record<string, unknown>> {
+  let wrappedHandler = cfg.handler;
+  const middlewares = cfg.middlewares ?? [];
+  for (let index = middlewares.length - 1; index >= 0; index -= 1) {
+    wrappedHandler = middlewares[index](wrappedHandler);
+  }
+  let value: unknown;
+  try {
+    value = await wrappedHandler(request);
+  } catch (error) {
+    value = failureResult(request.jobId, error instanceof Error ? error.message : String(error));
+  }
+  const result = isRecord(value)
+    ? value
+    : failureResult(request.jobId, "handler returned null");
+  if (typeof result.jobId !== "string" || result.jobId.length === 0) {
+    result.jobId = request.jobId ?? "";
+  }
+  if (typeof result.workerId !== "string" || result.workerId.length === 0) {
+    result.workerId = cfg.senderId;
+  }
+  return result;
+}
+
+function failureResult(jobId: string | undefined, errorMessage: string): Record<string, unknown> {
+  return { jobId: jobId ?? "", status: "JOB_STATUS_FAILED", errorMessage };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordResultMetrics(
+  metrics: MetricsHook,
+  result: Record<string, unknown>,
+  elapsedMs: number
+): void {
+  const jobId = String(result.jobId ?? "");
+  if (result.status === "JOB_STATUS_FAILED") {
+    metrics.onJobFailed(jobId, String(result.errorMessage ?? ""));
+    return;
+  }
+  metrics.onJobCompleted(
+    jobId,
+    elapsedMs,
+    String(result.status ?? "JOB_STATUS_SUCCEEDED")
+  );
+}
+
+async function publishWorkerResult(
+  cfg: WorkerConfig,
+  types: WorkerTypes,
+  packet: PacketView,
+  result: Record<string, unknown>
+): Promise<void> {
+  const resultMessage = types.jobResult.fromObject(result);
+  const outgoing = types.busPacket.fromObject({
+    traceId: packet.traceId,
+    senderId: cfg.senderId,
+    protocolVersion: DEFAULT_PROTOCOL_VERSION,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
+    jobResult: resultMessage,
+  }) as unknown as SignablePacket;
+  if (cfg.privateKey) {
+    const signer = crypto.createSign("sha256");
+    signer.update(encodeUnsignedForSignature(types.busPacket, outgoing));
+    outgoing.signature = signer.sign(cfg.privateKey);
+  }
+  const data = encodeDeterministic(types.busPacket, outgoing);
+  await cfg.nc.publish(SUBJECT_RESULT, data);
 }

--- a/sdk/node/test/handshake.test.ts
+++ b/sdk/node/test/handshake.test.ts
@@ -2,22 +2,23 @@ import assert from "node:assert";
 import { Agent, InMemoryBlobStore } from "../src/runtime";
 import { handshakePayload } from "../src/handshake";
 import { loadRoot } from "../src/protos";
+import type { Subscription, SubscriptionOptions } from "nats";
 
 class MockNatsConnection {
   published: Array<{ subject: string; data: Uint8Array }> = [];
-  subscriptions: Map<string, (msg: any) => void> = new Map();
+  subscriptions: Map<string, NonNullable<SubscriptionOptions["callback"]>> = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this.published.push({ subject, data });
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: any) => void): any {
-    if (cb) {
-      this.subscriptions.set(subject, cb);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this.subscriptions.set(subject, opts.callback);
     }
     return {
       drain: async () => {},
-    };
+    } as unknown as Subscription;
   }
 
   async drain(): Promise<void> {

--- a/sdk/node/test/integration/nats-server.ts
+++ b/sdk/node/test/integration/nats-server.ts
@@ -46,7 +46,7 @@ export class NatsServer {
       if (child.exitCode !== null) {
         throw new Error(`NATS exited ${child.exitCode}: ${this.output}`);
       }
-      return canConnect(this.port);
+      return isNatsReady(this.port);
     }, START_TIMEOUT_MS, `NATS did not listen on ${this.url}: ${this.output}`);
   }
 
@@ -65,7 +65,7 @@ export class NatsServer {
       }
       await waitForExit(child);
       await waitForCondition(
-        async () => !(await canConnect(this.port)),
+        async () => !(await isNatsReady(this.port)),
         5_000,
         `NATS endpoint ${this.url} remained open`,
       );
@@ -121,10 +121,11 @@ export async function reservePort(): Promise<number> {
   });
 }
 
-async function canConnect(port: number): Promise<boolean> {
+export async function isNatsReady(port: number): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const socket = net.createConnection({ host: "127.0.0.1", port });
     let finished = false;
+    let preamble = "";
     const finish = (connected: boolean): void => {
       if (finished) return;
       finished = true;
@@ -132,8 +133,13 @@ async function canConnect(port: number): Promise<boolean> {
       resolve(connected);
     };
     socket.setTimeout(250, () => finish(false));
-    socket.once("connect", () => finish(true));
+    socket.on("data", (chunk: Buffer) => {
+      preamble += chunk.toString("utf8");
+      if (preamble.startsWith("INFO ")) finish(true);
+      else if (preamble.length >= 5) finish(false);
+    });
     socket.once("error", () => finish(false));
+    socket.once("end", () => finish(false));
   });
 }
 

--- a/sdk/node/test/integration/nats-server.ts
+++ b/sdk/node/test/integration/nats-server.ts
@@ -1,0 +1,176 @@
+import { ChildProcess, execFileSync, spawn } from "node:child_process";
+import net from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+
+const NATS_IMAGE = "nats:2.10.25-alpine";
+const NATS_VERSION = "2.10.25";
+const START_TIMEOUT_MS = 8_000;
+
+interface CommandSpec {
+  command: string;
+  args: string[];
+}
+
+export class NatsServer {
+  private child?: ChildProcess;
+  private output = "";
+  private readonly binary =
+    process.env.CAP_NATS_SERVER_BIN ?? process.env.NATS_SERVER_BIN;
+  private readonly containerName = `cap-node-e2e-${process.pid}-${Date.now()}`;
+
+  constructor(readonly port: number) {}
+
+  get url(): string {
+    return `nats://127.0.0.1:${this.port}`;
+  }
+
+  async start(): Promise<void> {
+    if (this.child?.exitCode === null) {
+      throw new Error("NATS server is already running");
+    }
+    const spec = this.command();
+    this.output = "";
+    let spawnError: Error | undefined;
+    const child = spawn(spec.command, spec.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    child.once("error", (error: Error) => {
+      spawnError = error;
+    });
+    child.stdout?.on("data", (chunk: Buffer) => this.appendOutput(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => this.appendOutput(chunk));
+    this.child = child;
+    await waitForCondition(async () => {
+      if (spawnError) throw spawnError;
+      if (child.exitCode !== null) {
+        throw new Error(`NATS exited ${child.exitCode}: ${this.output}`);
+      }
+      return canConnect(this.port);
+    }, START_TIMEOUT_MS, `NATS did not listen on ${this.url}: ${this.output}`);
+  }
+
+  async stop(strict = true): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    try {
+      if (child.exitCode === null && this.binary) {
+        child.kill();
+      } else if (child.exitCode === null) {
+        execFileSync("docker", ["stop", "-t", "1", this.containerName], {
+          stdio: "pipe",
+          timeout: 10_000,
+          windowsHide: true,
+        });
+      }
+      await waitForExit(child);
+      await waitForCondition(
+        async () => !(await canConnect(this.port)),
+        5_000,
+        `NATS endpoint ${this.url} remained open`,
+      );
+    } catch (error) {
+      if (strict) throw error;
+    } finally {
+      this.child = undefined;
+    }
+  }
+
+  private command(): CommandSpec {
+    if (this.binary) {
+      const version = execFileSync(this.binary, ["-v"], {
+        encoding: "utf8",
+        timeout: 5_000,
+        windowsHide: true,
+      });
+      if (!version.includes(`v${NATS_VERSION}`)) {
+        throw new Error(`expected nats-server v${NATS_VERSION}, got ${version.trim()}`);
+      }
+      return {
+        command: this.binary,
+        args: ["-a", "127.0.0.1", "-p", String(this.port)],
+      };
+    }
+    return {
+      command: "docker",
+      args: [
+        "run", "--rm", "--name", this.containerName,
+        "-p", `127.0.0.1:${this.port}:4222`, NATS_IMAGE,
+      ],
+    };
+  }
+
+  private appendOutput(chunk: Buffer): void {
+    this.output = `${this.output}${chunk.toString("utf8")}`.slice(-8_192);
+  }
+}
+
+export async function reservePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve a TCP port"));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function canConnect(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let finished = false;
+    const finish = (connected: boolean): void => {
+      if (finished) return;
+      finished = true;
+      socket.destroy();
+      resolve(connected);
+    };
+    socket.setTimeout(250, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+export async function waitForCondition(
+  check: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await delay(50);
+  }
+  throw new Error(message);
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+  await withTimeout(
+    new Promise<void>((resolve) => child.once("exit", () => resolve())),
+    5_000,
+    "NATS server did not exit",
+  );
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/sdk/node/test/integration/nats.e2e.ts
+++ b/sdk/node/test/integration/nats.e2e.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  Events,
+  Msg,
+  NatsConnection,
+  NatsError,
+  Subscription,
+} from "nats";
+import { Type } from "protobufjs";
+import { connectNATS } from "../../src/bus";
+import { submitJob } from "../../src/client";
+import {
+  loadRoot,
+  SUBJECT_RESULT,
+  SUBJECT_SUBMIT,
+} from "../../src/protos";
+import { startWorker } from "../../src/worker";
+import {
+  NatsServer,
+  reservePort,
+  waitForCondition,
+  withTimeout,
+} from "./nats-server";
+
+const EVENT_TIMEOUT_MS = 8_000;
+
+interface DecodedResult {
+  jobId: string;
+  status: number;
+}
+
+interface ResultPacketShape {
+  jobResult?: {
+    jobId?: unknown;
+    status?: unknown;
+  };
+}
+
+interface ResultCollector {
+  records: DecodedResult[];
+  error?: Error;
+  subscription: Subscription;
+}
+
+interface StatusProbe {
+  events: string[];
+  done: Promise<void>;
+}
+
+interface ScenarioStatus {
+  worker: StatusProbe;
+  client: StatusProbe;
+}
+
+interface ScenarioState {
+  server: NatsServer;
+  calls: Map<string, number>;
+  statusTasks: Promise<void>[];
+  workerConnection?: NatsConnection;
+  clientConnection?: NatsConnection;
+  workerSubscription?: Subscription;
+  results?: ResultCollector;
+}
+
+function watchStatus(connection: NatsConnection): StatusProbe {
+  const events: string[] = [];
+  const done = (async () => {
+    for await (const status of connection.status()) {
+      events.push(status.type);
+    }
+  })();
+  return { events, done };
+}
+
+async function waitForEvent(
+  probe: StatusProbe,
+  event: Events,
+  afterIndex = -1,
+): Promise<number> {
+  await waitForCondition(
+    () => probe.events.indexOf(event, afterIndex + 1) >= 0,
+    EVENT_TIMEOUT_MS,
+    `timed out waiting for NATS ${event}; saw ${probe.events.join(",")}`,
+  );
+  return probe.events.indexOf(event, afterIndex + 1);
+}
+
+function decodeResult(type: Type, data: Uint8Array): DecodedResult {
+  const packet = type.toObject(type.decode(data), {
+    defaults: false,
+    enums: Number,
+  }) as ResultPacketShape;
+  const jobId = packet.jobResult?.jobId;
+  const status = packet.jobResult?.status;
+  if (typeof jobId !== "string" || typeof status !== "number") {
+    throw new Error("result packet lacked typed jobId/status");
+  }
+  return { jobId, status };
+}
+
+async function collectResults(connection: NatsConnection): Promise<ResultCollector> {
+  const root = await loadRoot();
+  const type = root.lookupType("cordum.agent.v1.BusPacket");
+  const collector: Omit<ResultCollector, "subscription"> = { records: [] };
+  const subscription = connection.subscribe(SUBJECT_RESULT, {
+    callback: (error: NatsError | null, message: Msg) => {
+      if (error) {
+        collector.error = error;
+        return;
+      }
+      try {
+        collector.records.push(decodeResult(type, message.data));
+      } catch (decodeError) {
+        collector.error = decodeError instanceof Error ? decodeError : new Error(String(decodeError));
+      }
+    },
+  });
+  await connection.flush();
+  return { ...collector, subscription };
+}
+
+function readJobId(value: unknown): string {
+  if (!value || typeof value !== "object") throw new Error("job request was not an object");
+  const jobId = (value as Record<string, unknown>).jobId;
+  if (typeof jobId !== "string") throw new Error("job request lacked jobId");
+  return jobId;
+}
+
+async function submitAndExpect(
+  connection: NatsConnection,
+  collector: ResultCollector,
+  jobId: string,
+  calls: ReadonlyMap<string, number>,
+): Promise<void> {
+  await submitJob(connection, {
+    jobId,
+    topic: "job.real-nats",
+    contextPtr: `memory://${jobId}`,
+  }, `trace-${jobId}`, "e2e-client");
+  await waitForCondition(() => {
+    if (collector.error) throw collector.error;
+    return collector.records.some((record) => record.jobId === jobId);
+  }, 4_000, `timed out waiting for result ${jobId}; handlerCalls=${calls.get(jobId) ?? 0}`);
+  await delay(150);
+  const matches = collector.records.filter((record) => record.jobId === jobId);
+  assert.equal(matches.length, 1, `expected exactly one result for ${jobId}`);
+  assert.equal(matches[0].status, 5, `expected succeeded result for ${jobId}`);
+}
+
+async function drainSubscription(subscription?: Subscription): Promise<void> {
+  if (!subscription || subscription.isClosed()) return;
+  try {
+    await withTimeout(subscription.drain(), 2_000, "subscription drain timed out");
+  } catch {
+    subscription.unsubscribe();
+  }
+}
+
+async function drainConnection(connection?: NatsConnection): Promise<void> {
+  if (!connection || connection.isClosed()) return;
+  try {
+    await withTimeout(connection.drain(), 2_000, "connection drain timed out");
+  } catch {
+    await connection.close();
+  }
+}
+
+async function startScenario(state: ScenarioState): Promise<ScenarioStatus> {
+  await state.server.start();
+  state.workerConnection = await connectNATS({
+    url: state.server.url,
+    name: "cap-e2e-worker",
+  });
+  state.clientConnection = await connectNATS({
+    url: state.server.url,
+    name: "cap-e2e-client",
+  });
+  const workerStatus = watchStatus(state.workerConnection);
+  const clientStatus = watchStatus(state.clientConnection);
+  state.statusTasks.push(workerStatus.done, clientStatus.done);
+  state.results = await collectResults(state.clientConnection);
+  state.workerSubscription = await startWorker({
+    nc: state.workerConnection,
+    subject: SUBJECT_SUBMIT,
+    senderId: "e2e-worker",
+    handler: async (request: unknown) => {
+      const jobId = readJobId(request);
+      state.calls.set(jobId, (state.calls.get(jobId) ?? 0) + 1);
+      return {
+        jobId,
+        status: "JOB_STATUS_SUCCEEDED",
+        resultPtr: `memory://${jobId}/result`,
+      };
+    },
+  });
+  await state.workerConnection.flush();
+  await submitAndExpect(
+    state.clientConnection,
+    state.results,
+    "job-before-restart",
+    state.calls,
+  );
+  return { worker: workerStatus, client: clientStatus };
+}
+
+async function exerciseReconnect(state: ScenarioState): Promise<void> {
+  const status = await startScenario(state);
+  const { clientConnection, results, workerSubscription } = state;
+  if (!clientConnection || !results || !workerSubscription) {
+    throw new Error("NATS scenario setup did not initialize required resources");
+  }
+  await state.server.stop();
+  const workerDisconnected = await waitForEvent(status.worker, Events.Disconnect);
+  const clientDisconnected = await waitForEvent(status.client, Events.Disconnect);
+  await state.server.start();
+  await waitForEvent(status.worker, Events.Reconnect, workerDisconnected);
+  await waitForEvent(status.client, Events.Reconnect, clientDisconnected);
+  assert.equal(
+    workerSubscription.isClosed(),
+    false,
+    "original worker subscription closed",
+  );
+  await submitAndExpect(
+    clientConnection,
+    results,
+    "job-after-restart",
+    state.calls,
+  );
+
+  assert.deepEqual(results.records.map((record) => record.jobId), [
+    "job-before-restart",
+    "job-after-restart",
+  ]);
+  assert.deepEqual([...state.calls.entries()], [
+    ["job-before-restart", 1],
+    ["job-after-restart", 1],
+  ]);
+}
+
+async function cleanupScenario(state: ScenarioState): Promise<void> {
+  await drainSubscription(state.results?.subscription);
+  await drainSubscription(state.workerSubscription);
+  await drainConnection(state.clientConnection);
+  await drainConnection(state.workerConnection);
+  await state.server.stop(false);
+  await withTimeout(
+    Promise.allSettled(state.statusTasks),
+    1_000,
+    "NATS status watchers did not close",
+  ).catch(() => undefined);
+}
+
+async function runReconnectScenario(): Promise<void> {
+  const state: ScenarioState = {
+    server: new NatsServer(await reservePort()),
+    calls: new Map<string, number>(),
+    statusTasks: [],
+  };
+  try {
+    await exerciseReconnect(state);
+  } finally {
+    await cleanupScenario(state);
+  }
+}
+
+describe("Node SDK real NATS transport", () => {
+  it("keeps the original worker subscription after a disconnect and reconnect", async function () {
+    this.timeout(30_000);
+    await runReconnectScenario();
+  });
+});

--- a/sdk/node/test/integration/nats.e2e.ts
+++ b/sdk/node/test/integration/nats.e2e.ts
@@ -117,7 +117,7 @@ async function collectResults(connection: NatsConnection): Promise<ResultCollect
     },
   });
   await connection.flush();
-  return { ...collector, subscription };
+  return Object.assign(collector, { subscription });
 }
 
 function readJobId(value: unknown): string {
@@ -265,6 +265,24 @@ async function runReconnectScenario(): Promise<void> {
 }
 
 describe("Node SDK real NATS transport", () => {
+  it("keeps late result callback errors observable", async () => {
+    let callback: ((error: NatsError | null, message: Msg) => void) | undefined;
+    const subscription = {} as Subscription;
+    const connection = {
+      subscribe: (_subject: string, options: { callback: typeof callback }) => {
+        callback = options.callback;
+        return subscription;
+      },
+      flush: async () => undefined,
+    } as unknown as NatsConnection;
+    const collector = await collectResults(connection);
+    const error = new Error("injected result callback failure");
+
+    assert.ok(callback);
+    callback(error as NatsError, {} as Msg);
+    assert.equal(collector.error, error);
+  });
+
   it("keeps the original worker subscription after a disconnect and reconnect", async function () {
     this.timeout(30_000);
     await runReconnectScenario();

--- a/sdk/node/test/lifecycle.test.ts
+++ b/sdk/node/test/lifecycle.test.ts
@@ -1,0 +1,300 @@
+import assert from "node:assert";
+import type {
+  Msg,
+  NatsConnection,
+  NatsError,
+  Subscription,
+  SubscriptionOptions,
+} from "nats";
+import { Agent, InMemoryBlobStore } from "../src/runtime";
+import { encodeDeterministic } from "../src/codec";
+import { loadRoot } from "../src/protos";
+import type { Logger } from "../src/logger";
+
+type MessageCallback = NonNullable<SubscriptionOptions["callback"]>;
+
+class RecordingStore extends InMemoryBlobStore {
+  closeCount = 0;
+
+  constructor(private readonly events: string[]) {
+    super();
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+    this.events.push("store-close");
+  }
+}
+
+class LifecycleNatsConnection {
+  callback?: MessageCallback;
+  connectionDrainCount = 0;
+  failResultPublish = false;
+  failSubscribe = false;
+  subscriptionDrainCount = 0;
+
+  constructor(private readonly events: string[]) {}
+
+  publish(subject: string, _data: Uint8Array): void {
+    if (subject === "sys.job.result") {
+      this.events.push("result-publish");
+      if (this.failResultPublish) {
+        throw new Error("injected result publish failure");
+      }
+    }
+  }
+
+  subscribe(
+    _subject: string,
+    opts: SubscriptionOptions = {},
+    legacyCallback?: MessageCallback
+  ): Subscription {
+    if (this.failSubscribe) {
+      throw new Error("injected subscribe failure");
+    }
+    // The fallback isolates lifecycle behavior while other tests enforce the real API.
+    this.callback = opts.callback ?? legacyCallback;
+    return {
+      drain: async () => {
+        this.subscriptionDrainCount += 1;
+        this.events.push("subscription-drain");
+      },
+    } as unknown as Subscription;
+  }
+
+  async drain(): Promise<void> {
+    this.connectionDrainCount += 1;
+    this.events.push("connection-drain");
+  }
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function jobMessage(topic: string, jobId: string): Promise<Msg> {
+  const root = await loadRoot();
+  const busPacket = root.lookupType("cordum.agent.v1.BusPacket");
+  const packet = busPacket.fromObject({
+    traceId: `trace-${jobId}`,
+    senderId: "lifecycle-client",
+    protocolVersion: 1,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
+    jobRequest: { jobId, topic, contextPtr: `redis://ctx:${jobId}` },
+  });
+  return { data: encodeDeterministic(busPacket, packet) } as Msg;
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+function recordingLogger(errors: string[]): Logger {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: (message, fields) => errors.push(`${message} ${String(fields?.error ?? "")}`),
+  };
+}
+
+function assertShutdownOrder(events: string[]): void {
+  const ordered = [
+    "handler-finish",
+    "result-publish",
+    "connection-drain",
+    "store-close",
+  ];
+  assert.deepStrictEqual(events.filter((event) => ordered.includes(event)), ordered);
+}
+
+async function waitsForInFlightBeforeClosing(): Promise<void> {
+  const events: string[] = [];
+  const store = new RecordingStore(events);
+  const nc = new LifecycleNatsConnection(events);
+  const releaseHandler = deferred();
+  const handlerStarted = deferred();
+  const topic = "job.lifecycle.blocked";
+  const jobId = "lifecycle-blocked";
+  await store.set(`ctx:${jobId}`, Buffer.from("{}"));
+
+  const agent = new Agent({
+    store,
+    connectFn: async () => nc as unknown as NatsConnection,
+    senderId: "lifecycle-worker",
+    heartbeatInterval: 60_000,
+  });
+  agent.job(topic, async () => {
+    events.push("handler-start");
+    handlerStarted.resolve();
+    await releaseHandler.promise;
+    events.push("handler-finish");
+    return { ok: true };
+  });
+
+  await agent.start();
+  events.length = 0;
+  assert.ok(nc.callback, "Agent must register a subscription callback");
+  nc.callback(null, await jobMessage(topic, jobId));
+  await handlerStarted.promise;
+
+  let closeSettled = false;
+  const closePromise = agent.close().then(() => {
+    closeSettled = true;
+  });
+  try {
+    await tick();
+    assert.strictEqual(closeSettled, false, "close resolved while handler was blocked");
+    assert.ok(events.includes("subscription-drain"), "intake was not drained first");
+    assert.ok(!events.includes("store-close"), "store closed before the handler finished");
+  } finally {
+    releaseHandler.resolve();
+    await closePromise;
+  }
+
+  assertShutdownOrder(events);
+}
+
+async function coalescesConcurrentClose(): Promise<void> {
+  const events: string[] = [];
+  const store = new RecordingStore(events);
+  const nc = new LifecycleNatsConnection(events);
+  const agent = new Agent({
+    store,
+    connectFn: async () => nc as unknown as NatsConnection,
+    heartbeatInterval: 60_000,
+  });
+  agent.job("job.lifecycle.close", async () => ({}));
+  await agent.start();
+
+  await Promise.all([agent.close(), agent.close()]);
+
+  assert.strictEqual(nc.connectionDrainCount, 1);
+  assert.strictEqual(store.closeCount, 1);
+}
+
+async function rejectsDuplicateStarts(): Promise<void> {
+  const events: string[] = [];
+  const store = new RecordingStore(events);
+  let connectCount = 0;
+  const agent = new Agent({
+    store,
+    connectFn: async () => {
+      connectCount += 1;
+      return new LifecycleNatsConnection(events) as unknown as NatsConnection;
+    },
+    heartbeatInterval: 60_000,
+  });
+  agent.job("job.lifecycle.start", async () => ({}));
+  await agent.start();
+  try {
+    await assert.rejects(agent.start(), /already started/i);
+    assert.strictEqual(connectCount, 1);
+  } finally {
+    await agent.close();
+  }
+}
+
+async function cleansUpFailedStartup(): Promise<void> {
+  const events: string[] = [];
+  const store = new RecordingStore(events);
+  const nc = new LifecycleNatsConnection(events);
+  nc.failSubscribe = true;
+  const agent = new Agent({
+    store,
+    connectFn: async () => nc as unknown as NatsConnection,
+    heartbeatInterval: 60_000,
+  });
+  agent.job("job.lifecycle.start-failure", async () => ({}));
+
+  await assert.rejects(agent.start(), /injected subscribe failure/);
+
+  assert.strictEqual(nc.connectionDrainCount, 1);
+  assert.strictEqual(store.closeCount, 1);
+  await agent.close();
+  assert.strictEqual(nc.connectionDrainCount, 1);
+  assert.strictEqual(store.closeCount, 1);
+}
+
+async function handlesSubscriptionCallbackErrors(): Promise<void> {
+  const errors: string[] = [];
+  const nc = new LifecycleNatsConnection([]);
+  let handlerCalls = 0;
+  const agent = new Agent({
+    store: new InMemoryBlobStore(),
+    connectFn: async () => nc as unknown as NatsConnection,
+    heartbeatInterval: 60_000,
+    logger: recordingLogger(errors),
+  });
+  agent.job("job.lifecycle.callback-error", async () => {
+    handlerCalls += 1;
+    return {};
+  });
+  await agent.start();
+  try {
+    assert.ok(nc.callback);
+    nc.callback(
+      new Error("injected callback failure") as unknown as NatsError,
+      {} as Msg
+    );
+    await tick();
+    assert.strictEqual(handlerCalls, 0);
+    assert.ok(errors.some((entry) => entry.includes("injected callback failure")));
+  } finally {
+    await agent.close();
+  }
+}
+
+async function catchesRejectedMessageProcessing(): Promise<void> {
+  const errors: string[] = [];
+  const unhandled: unknown[] = [];
+  const nc = new LifecycleNatsConnection([]);
+  const store = new InMemoryBlobStore();
+  const jobId = "lifecycle-rejection";
+  await store.set(`ctx:${jobId}`, Buffer.from("{}"));
+  const agent = new Agent({
+    store,
+    connectFn: async () => nc as unknown as NatsConnection,
+    heartbeatInterval: 60_000,
+    logger: recordingLogger(errors),
+  });
+  agent.job("job.lifecycle.rejection", async () => ({ ok: true }));
+  const capture = (reason: unknown): void => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", capture);
+  try {
+    await agent.start();
+    nc.failResultPublish = true;
+    assert.ok(nc.callback);
+    nc.callback(null, await jobMessage("job.lifecycle.rejection", jobId));
+    await tick();
+    assert.deepStrictEqual(unhandled, []);
+    assert.ok(errors.some((entry) => entry.includes("message processing failed")));
+  } finally {
+    process.off("unhandledRejection", capture);
+    nc.failResultPublish = false;
+    await agent.close();
+  }
+}
+
+describe("Agent lifecycle", () => {
+  it(
+    "waits for an in-flight handler and result before closing resources",
+    waitsForInFlightBeforeClosing
+  );
+  it("coalesces concurrent close calls", coalescesConcurrentClose);
+  it("rejects duplicate starts without opening another connection", rejectsDuplicateStarts);
+  it("cleans up an opened connection and store when startup fails", cleansUpFailedStartup);
+  it(
+    "logs subscription callback errors without invoking a handler",
+    handlesSubscriptionCallbackErrors
+  );
+  it(
+    "catches rejected message processing instead of leaking an unhandled rejection",
+    catchesRejectedMessageProcessing
+  );
+});

--- a/sdk/node/test/metrics.test.ts
+++ b/sdk/node/test/metrics.test.ts
@@ -4,20 +4,21 @@ import { loadRoot } from "../src/protos";
 import { encodeDeterministic } from "../src/codec";
 import type { MetricsHook } from "../src/metrics";
 import { noopMetrics } from "../src/metrics";
+import type { Msg, Subscription, SubscriptionOptions } from "nats";
 
 class MockNatsConnection {
   published: Array<{ subject: string; data: Uint8Array }> = [];
-  subscriptions: Map<string, (msg: any) => void> = new Map();
+  subscriptions: Map<string, NonNullable<SubscriptionOptions["callback"]>> = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this.published.push({ subject, data });
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: any) => void): any {
-    if (cb) {
-      this.subscriptions.set(subject, cb);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this.subscriptions.set(subject, opts.callback);
     }
-    return { drain: async () => {} };
+    return { drain: async () => {} } as unknown as Subscription;
   }
 
   async drain(): Promise<void> {
@@ -79,12 +80,13 @@ describe("MetricsHook", () => {
       traceId: "t1",
       senderId: "c1",
       protocolVersion: 1,
+      createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobRequest: { jobId, topic: "job.metrics", contextPtr: `redis://${ctxKey}` },
     });
     const data = encodeDeterministic(BusPacket, packetObj);
 
     const cb = mock.subscriptions.get("job.metrics")!;
-    cb({ data });
+    cb(null, { data } as Msg);
 
     await waitFor(() => metrics.completed.length > 0);
 
@@ -123,12 +125,13 @@ describe("MetricsHook", () => {
       traceId: "t2",
       senderId: "c2",
       protocolVersion: 1,
+      createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobRequest: { jobId, topic: "job.metrics.fail", contextPtr: "redis://missing-key" },
     });
     const data = encodeDeterministic(BusPacket, packetObj);
 
     const cb = mock.subscriptions.get("job.metrics.fail")!;
-    cb({ data });
+    cb(null, { data } as Msg);
 
     await waitFor(() => metrics.failed.length > 0);
 

--- a/sdk/node/test/middleware.test.ts
+++ b/sdk/node/test/middleware.test.ts
@@ -4,20 +4,21 @@ import { Agent, InMemoryBlobStore } from "../src/runtime";
 import { loadRoot } from "../src/protos";
 import { encodeDeterministic } from "../src/codec";
 import { Middleware, loggingMiddleware } from "../src/middleware";
+import type { Msg, Subscription, SubscriptionOptions } from "nats";
 
 class MockNatsConnection {
   published: Array<{ subject: string; data: Uint8Array }> = [];
-  subscriptions: Map<string, (msg: any) => void> = new Map();
+  subscriptions: Map<string, NonNullable<SubscriptionOptions["callback"]>> = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this.published.push({ subject, data });
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: any) => void): any {
-    if (cb) {
-      this.subscriptions.set(subject, cb);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this.subscriptions.set(subject, opts.callback);
     }
-    return { drain: async () => {} };
+    return { drain: async () => {} } as unknown as Subscription;
   }
 
   async drain(): Promise<void> {
@@ -45,12 +46,13 @@ async function sendJob(mock: MockNatsConnection, topic: string, jobId: string, c
     traceId: "trace-mw",
     senderId: "client-mw",
     protocolVersion: 1,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
     jobRequest: { jobId, topic, contextPtr: `redis://${ctxKey}` },
   });
   const payload = encodeDeterministic(BusPacket, packet);
   const cb = mock.subscriptions.get(topic);
   assert.ok(cb);
-  cb?.({ data: payload });
+  cb?.(null, { data: payload } as Msg);
 }
 
 describe("Middleware (node)", () => {

--- a/sdk/node/test/nats-server-readiness.test.ts
+++ b/sdk/node/test/nats-server-readiness.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import { isNatsReady, reservePort } from "./integration/nats-server";
+
+async function listenWithoutNatsProtocol(port: number): Promise<net.Server> {
+  const server = net.createServer(() => undefined);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return server;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+describe("NATS server readiness", () => {
+  it("does not treat a TCP-only listener as a ready NATS server", async () => {
+    const server = await listenWithoutNatsProtocol(await reservePort());
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    try {
+      assert.equal(await isNatsReady(address.port), false);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/sdk/node/test/runtime.test.ts
+++ b/sdk/node/test/runtime.test.ts
@@ -3,22 +3,23 @@ import { z } from "zod";
 import { Agent, InMemoryBlobStore } from "../src/runtime";
 import { loadRoot } from "../src/protos";
 import { encodeDeterministic } from "../src/codec";
+import type { Msg, Subscription, SubscriptionOptions } from "nats";
 
 class MockNatsConnection {
   published: Array<{ subject: string; data: Uint8Array }> = [];
-  subscriptions: Map<string, (msg: any) => void> = new Map();
+  subscriptions: Map<string, NonNullable<SubscriptionOptions["callback"]>> = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this.published.push({ subject, data });
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: any) => void): any {
-    if (cb) {
-      this.subscriptions.set(subject, cb);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this.subscriptions.set(subject, opts.callback);
     }
     return {
       drain: async () => {},
-    };
+    } as unknown as Subscription;
   }
 
   async drain(): Promise<void> {
@@ -78,13 +79,14 @@ describe("CAP runtime (node)", () => {
       traceId: "trace-1",
       senderId: "client-1",
       protocolVersion: 1,
+      createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobRequest: { jobId, topic: "job.test", contextPtr: `redis://${ctxKey}` },
     });
     const payload = encodeDeterministic(BusPacket, packet);
 
     const cb = mock.subscriptions.get("job.test");
     assert.ok(cb);
-    cb?.({ data: payload });
+    cb?.(null, { data: payload } as Msg);
 
     const result = await waitForPublishedSubject(mock, "sys.job.result");
     const resultPacket = BusPacket.decode(result.data) as any;
@@ -126,13 +128,14 @@ describe("CAP runtime (node)", () => {
       traceId: "trace-2",
       senderId: "client-2",
       protocolVersion: 1,
+      createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobRequest: { jobId, topic: "job.validate", contextPtr: `redis://${ctxKey}` },
     });
     const payload = encodeDeterministic(BusPacket, packet);
 
     const cb = mock.subscriptions.get("job.validate");
     assert.ok(cb);
-    cb?.({ data: payload });
+    cb?.(null, { data: payload } as Msg);
 
     const result = await waitForPublishedSubject(mock, "sys.job.result");
     const resultPacket = BusPacket.decode(result.data) as any;
@@ -176,13 +179,14 @@ describe("CAP runtime (node)", () => {
       traceId: "trace-3",
       senderId: "client-3",
       protocolVersion: 1,
+      createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobRequest: { jobId, topic: "job.retry", contextPtr: `redis://${ctxKey}` },
     });
     const payload = encodeDeterministic(BusPacket, packet);
 
     const cb = mock.subscriptions.get("job.retry");
     assert.ok(cb);
-    cb?.({ data: payload });
+    cb?.(null, { data: payload } as Msg);
 
     const result = await waitForPublishedSubject(mock, "sys.job.result");
     const resultPacket = BusPacket.decode(result.data) as any;

--- a/sdk/node/test/sdk.test.ts
+++ b/sdk/node/test/sdk.test.ts
@@ -1,4 +1,4 @@
-import { NatsConnection, Msg, Subscription } from "nats";
+import { NatsConnection, Msg, Subscription, SubscriptionOptions } from "nats";
 import { submitJob } from "../src/client";
 import { startWorker } from "../src/worker";
 import { loadRoot } from "../src/protos";
@@ -10,15 +10,16 @@ import assert from "node:assert";
 // Mock NatsConnection
 class MockNatsConnection {
   _publishedMessages: Msg[] = [];
-  _subscriptions: Map<string, (msg: Msg) => void> = new Map();
+  _subscriptions: Map<string, NonNullable<SubscriptionOptions["callback"]>> = new Map();
 
   async publish(subject: string, data: Uint8Array): Promise<void> {
     this._publishedMessages.push({ subject, data } as Msg);
   }
 
-  subscribe(subject: string, _opts?: any, cb?: (msg: Msg) => void): Subscription {
-    const callback = cb ?? (() => {});
-    this._subscriptions.set(subject, callback);
+  subscribe(subject: string, opts: SubscriptionOptions = {}): Subscription {
+    if (opts.callback) {
+      this._subscriptions.set(subject, opts.callback);
+    }
     return {
       getSubject: () => subject,
       getReceived: () => 1, // Dummy value
@@ -28,8 +29,17 @@ class MockNatsConnection {
       isClosed: () => false,
       drain: async () => {},
       unsubscribe: () => {},
-    } as any; // Cast to any
+    } as unknown as Subscription;
   }
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for worker result");
 }
 
 describe("CAP SDK E2E Test", () => {
@@ -96,7 +106,8 @@ describe("CAP SDK E2E Test", () => {
     const workerCallback = mockNats._subscriptions.get(testSubject);
     assert.ok(workerCallback);
     if (workerCallback) {
-      await workerCallback(clientPublishedMsg);
+      await workerCallback(null, clientPublishedMsg);
+      await waitFor(() => mockNats._publishedMessages.length === 2);
     } else {
         throw new Error("Worker did not subscribe correctly");
     }

--- a/sdk/node/test/security-key-policy.test.ts
+++ b/sdk/node/test/security-key-policy.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import * as crypto from "node:crypto";
+import type { KeyObject } from "node:crypto";
+import type { Type } from "protobufjs";
+import { encodeUnsignedForSignature } from "../src/codec";
+import { SignatureInvalidError } from "../src/errors";
+import { DEFAULT_PROTOCOL_VERSION, loadRoot } from "../src/protos";
+import { verifyInboundPacket } from "../src/security";
+
+interface SigningKeys {
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+}
+
+async function signedPacket(keys: SigningKeys): Promise<{
+  packetType: Type;
+  packet: unknown;
+}> {
+  const root = await loadRoot();
+  const packetType = root.lookupType("cordum.agent.v1.BusPacket");
+  const packet = packetType.fromObject({
+    traceId: "trace-key-policy",
+    senderId: "trusted-client",
+    protocolVersion: DEFAULT_PROTOCOL_VERSION,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
+    jobRequest: {
+      jobId: "job-key-policy",
+      topic: "job.security.key-policy",
+      contextPtr: "redis://ctx:job-key-policy",
+    },
+  }) as unknown as { signature?: Uint8Array };
+  const signer = crypto.createSign("sha256");
+  signer.update(encodeUnsignedForSignature(packetType, packet));
+  packet.signature = signer.sign(keys.privateKey);
+  return { packetType, packet };
+}
+
+async function assertKeyRejected(keys: SigningKeys): Promise<void> {
+  const { packetType, packet } = await signedPacket(keys);
+  const publicKey = keys.publicKey.export({ type: "spki", format: "pem" }).toString();
+  assert.throws(
+    () => verifyInboundPacket(packetType, packet, { "trusted-client": publicKey }),
+    SignatureInvalidError
+  );
+}
+
+describe("trusted inbound key policy", () => {
+  it("rejects an RSA trusted key", async () => {
+    await assertKeyRejected(crypto.generateKeyPairSync("rsa", { modulusLength: 2048 }));
+  });
+
+  it("rejects a non-P-256 EC trusted key", async () => {
+    await assertKeyRejected(
+      crypto.generateKeyPairSync("ec", { namedCurve: "secp384r1" })
+    );
+  });
+});

--- a/sdk/node/test/security.test.ts
+++ b/sdk/node/test/security.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert";
+import * as crypto from "node:crypto";
+import type {
+  Msg,
+  NatsConnection,
+  Subscription,
+  SubscriptionOptions,
+} from "nats";
+import { encodeDeterministic, encodeUnsignedForSignature } from "../src/codec";
+import type { Logger } from "../src/logger";
+import { DEFAULT_PROTOCOL_VERSION, loadRoot, SUBJECT_RESULT } from "../src/protos";
+import { Agent, InMemoryBlobStore } from "../src/runtime";
+import { startWorker } from "../src/worker";
+
+const TOPIC = "job.security";
+const TRUSTED_SENDER = "trusted-client";
+const privateKeyMap = crypto.generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+type Surface = "startWorker" | "Agent";
+type KeyMode = "unset" | "trusted" | "empty-map" | "empty-key" | "bad-key";
+type NatsCallback = NonNullable<SubscriptionOptions["callback"]>;
+type LegacyCallback = (msg: Msg) => void | Promise<void>;
+
+interface SecurityVector {
+  name: string;
+  keyMode: KeyMode;
+  senderId: string;
+  signed: boolean;
+  allowed: boolean;
+  omitTrace?: boolean;
+  tamperAfterSigning?: boolean;
+}
+
+interface PacketView {
+  signature?: Uint8Array;
+  jobRequest?: { jobId?: string };
+}
+
+interface CallbackEntry {
+  callback: NatsCallback;
+  mode: "options" | "legacy";
+}
+
+interface SurfaceHarness {
+  bus: SecurityBus;
+  handlerCalls: () => number;
+  close: () => Promise<void>;
+}
+
+const silentLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const vectors: SecurityVector[] = [
+  { name: "accepts a valid signed packet", keyMode: "trusted", senderId: TRUSTED_SENDER, signed: true, allowed: true },
+  { name: "allows legacy unsigned only when key map is undefined", keyMode: "unset", senderId: TRUSTED_SENDER, signed: false, allowed: true },
+  { name: "treats an empty key map as deny-all", keyMode: "empty-map", senderId: TRUSTED_SENDER, signed: true, allowed: false },
+  { name: "rejects an unsigned packet in strict mode", keyMode: "trusted", senderId: TRUSTED_SENDER, signed: false, allowed: false },
+  { name: "rejects an empty sender with a nonempty signature", keyMode: "trusted", senderId: "", signed: true, allowed: false },
+  { name: "rejects an unknown sender", keyMode: "trusted", senderId: "unknown-client", signed: true, allowed: false },
+  { name: "rejects a tampered signed packet", keyMode: "trusted", senderId: TRUSTED_SENDER, signed: true, allowed: false, tamperAfterSigning: true },
+  { name: "rejects a prototype-like sender", keyMode: "trusted", senderId: "__proto__", signed: true, allowed: false },
+  { name: "rejects a constructor-like sender", keyMode: "trusted", senderId: "constructor", signed: true, allowed: false },
+  { name: "rejects an empty public key", keyMode: "empty-key", senderId: TRUSTED_SENDER, signed: true, allowed: false },
+  { name: "rejects a malformed public key", keyMode: "bad-key", senderId: TRUSTED_SENDER, signed: true, allowed: false },
+  { name: "rejects an invalid envelope", keyMode: "trusted", senderId: TRUSTED_SENDER, signed: true, allowed: false, omitTrace: true },
+];
+
+class SecurityBus {
+  readonly published: Array<{ subject: string; data: Uint8Array }> = [];
+  private readonly callbacks = new Map<string, CallbackEntry>();
+  private readonly pendingLegacy = new Set<Promise<void>>();
+
+  publish(subject: string, data: Uint8Array): void {
+    this.published.push({ subject, data });
+  }
+
+  subscribe(
+    subject: string,
+    options: SubscriptionOptions = {},
+    legacyCallback?: LegacyCallback
+  ): Subscription {
+    if (options.callback) {
+      this.callbacks.set(subject, { callback: options.callback, mode: "options" });
+    } else if (legacyCallback) {
+      // Audit-only fallback: contract tests below stay RED while production uses arg 3.
+      const callback: NatsCallback = (_error, msg) => this.trackLegacy(legacyCallback(msg));
+      this.callbacks.set(subject, { callback, mode: "legacy" });
+    }
+    return fakeSubscription();
+  }
+
+  async deliver(subject: string, data: Uint8Array): Promise<void> {
+    const entry = this.callbacks.get(subject);
+    if (!entry) {
+      throw new Error(`no callback registered for ${subject}`);
+    }
+    entry.callback(null, { subject, data } as unknown as Msg);
+    await Promise.allSettled([...this.pendingLegacy]);
+    await delay(20);
+  }
+
+  callbackMode(subject: string): "options" | "legacy" | "none" {
+    return this.callbacks.get(subject)?.mode ?? "none";
+  }
+
+  resultCount(): number {
+    return this.published.filter((message) => message.subject === SUBJECT_RESULT).length;
+  }
+
+  async drain(): Promise<void> {}
+
+  private trackLegacy(result: void | Promise<void>): void {
+    if (!(result instanceof Promise)) return;
+    const tracked = result.finally(() => this.pendingLegacy.delete(tracked));
+    this.pendingLegacy.add(tracked);
+  }
+}
+
+function fakeSubscription(): Subscription {
+  return {
+    drain: async () => {},
+    unsubscribe: () => {},
+  } as unknown as Subscription;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function keyMapFor(mode: KeyMode): Record<string, string> | undefined {
+  if (mode === "unset") return undefined;
+  if (mode === "empty-map") return {};
+  if (mode === "empty-key") return { [TRUSTED_SENDER]: "" };
+  if (mode === "bad-key") return { [TRUSTED_SENDER]: "not-a-public-key" };
+  return { [TRUSTED_SENDER]: privateKeyMap.publicKey };
+}
+
+async function packetFor(vector: SecurityVector, jobId: string): Promise<Uint8Array> {
+  const root = await loadRoot();
+  const BusPacket = root.lookupType("cordum.agent.v1.BusPacket");
+  const envelope: Record<string, unknown> = {
+    senderId: vector.senderId,
+    protocolVersion: DEFAULT_PROTOCOL_VERSION,
+    createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
+    jobRequest: { jobId, topic: TOPIC, contextPtr: `redis://ctx:${jobId}` },
+  };
+  if (!vector.omitTrace) envelope.traceId = `trace-${jobId}`;
+
+  const packet = BusPacket.fromObject(envelope) as unknown as PacketView;
+  if (vector.signed) {
+    const signer = crypto.createSign("sha256");
+    signer.update(encodeUnsignedForSignature(BusPacket, packet));
+    packet.signature = signer.sign(privateKeyMap.privateKey);
+  }
+  if (vector.tamperAfterSigning && packet.jobRequest) {
+    packet.jobRequest.jobId = `${jobId}-tampered`;
+  }
+  return encodeDeterministic(BusPacket, packet);
+}
+
+async function createHarness(
+  surface: Surface,
+  publicKeyMap: Record<string, string> | undefined,
+  jobId: string,
+  logger: Logger = silentLogger
+): Promise<SurfaceHarness> {
+  const bus = new SecurityBus();
+  let calls = 0;
+  if (surface === "startWorker") {
+    const subscription = await startWorker({
+      nc: bus as unknown as NatsConnection,
+      subject: TOPIC,
+      senderId: "security-worker",
+      publicKeyMap,
+      logger,
+      handler: async (request: { jobId?: string }) => {
+        calls += 1;
+        return { jobId: request.jobId, status: "JOB_STATUS_SUCCEEDED" };
+      },
+    });
+    return { bus, handlerCalls: () => calls, close: () => subscription.drain() };
+  }
+
+  const store = new InMemoryBlobStore();
+  await store.set(`ctx:${jobId}`, Buffer.from("{}", "utf-8"));
+  const agent = new Agent({
+    store,
+    publicKeyMap,
+    senderId: "security-agent",
+    heartbeatInterval: 60_000,
+    logger,
+    connectFn: async () => bus as unknown as NatsConnection,
+  });
+  agent.job<Record<string, never>, { ok: boolean }>(TOPIC, async () => {
+    calls += 1;
+    return { ok: true };
+  });
+  await agent.start();
+  return { bus, handlerCalls: () => calls, close: () => agent.close() };
+}
+
+async function exercise(surface: Surface, vector: SecurityVector, jobId: string) {
+  const harness = await createHarness(surface, keyMapFor(vector.keyMode), jobId);
+  try {
+    await harness.bus.deliver(TOPIC, await packetFor(vector, jobId));
+    return {
+      handlerCalls: harness.handlerCalls(),
+      resultCount: harness.bus.resultCount(),
+    };
+  } finally {
+    await harness.close();
+  }
+}
+
+for (const surface of ["startWorker", "Agent"] as const) {
+  describe(`${surface} inbound security`, () => {
+    it("registers a NATS v2 callback inside subscription options", async () => {
+      const harness = await createHarness(surface, undefined, `contract-${surface}`);
+      try {
+        assert.strictEqual(harness.bus.callbackMode(TOPIC), "options");
+      } finally {
+        await harness.close();
+      }
+    });
+
+    for (const [index, vector] of vectors.entries()) {
+      it(vector.name, async () => {
+        const actual = await exercise(surface, vector, `${surface}-${index}`);
+        const expectedCount = vector.allowed ? 1 : 0;
+        assert.deepStrictEqual(actual, {
+          handlerCalls: expectedCount,
+          resultCount: expectedCount,
+        });
+      });
+    }
+
+    it("keeps rejected payload and key material out of logs", async () => {
+      const entries: string[] = [];
+      const logger: Logger = {
+        info: () => undefined,
+        warn: (message, fields) => entries.push(`${message} ${String(fields?.error ?? "")}`),
+        error: (message, fields) => entries.push(`${message} ${String(fields?.error ?? "")}`),
+      };
+      const secret = `payload-secret-${surface}`;
+      const harness = await createHarness(
+        surface,
+        keyMapFor("trusted"),
+        secret,
+        logger
+      );
+      try {
+        const invalid = { ...vectors[vectors.length - 1], omitTrace: true };
+        await harness.bus.deliver(TOPIC, await packetFor(invalid, secret));
+        const output = entries.join("\n");
+        assert.ok(output.includes("MalformedPacketError"));
+        assert.ok(!output.includes(secret));
+        assert.ok(!output.includes(privateKeyMap.publicKey.trim()));
+      } finally {
+        await harness.close();
+      }
+    });
+  });
+}

--- a/sdk/node/test/shutdown-timeout.test.ts
+++ b/sdk/node/test/shutdown-timeout.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import type { NatsConnection, Subscription } from "nats";
+import { Agent, InMemoryBlobStore } from "../src/runtime";
+
+class RecordingStore extends InMemoryBlobStore {
+  closeCount = 0;
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+class StalledDrainConnection {
+  closeCount = 0;
+  failUnsubscribe = false;
+  unsubscribeCount = 0;
+
+  publish(): void {}
+
+  subscribe(): Subscription {
+    return {
+      drain: async () => new Promise<void>(() => undefined),
+      unsubscribe: () => {
+        this.unsubscribeCount += 1;
+        if (this.failUnsubscribe) throw new Error("injected unsubscribe failure");
+      },
+    } as unknown as Subscription;
+  }
+
+  async drain(): Promise<void> {
+    return new Promise<void>(() => undefined);
+  }
+
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+async function failAfter(ms: number): Promise<never> {
+  await delay(ms);
+  throw new Error("Agent.close stalled on a NATS drain");
+}
+
+const silentLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+function newAgent(store: RecordingStore, connection: StalledDrainConnection): Agent {
+  const agent = new Agent({
+    store,
+    connectFn: async () => connection as unknown as NatsConnection,
+    heartbeatInterval: 60_000,
+    ioTimeoutMs: 10,
+    logger: silentLogger,
+  });
+  agent.job("job.shutdown.timeout", async () => ({}));
+  return agent;
+}
+
+describe("bounded NATS shutdown", () => {
+  it("falls back to unsubscribe and close when drains do not settle", async () => {
+    const store = new RecordingStore();
+    const connection = new StalledDrainConnection();
+    const agent = newAgent(store, connection);
+    await agent.start();
+
+    await Promise.race([agent.close(), failAfter(200)]);
+
+    assert.equal(connection.unsubscribeCount, 1);
+    assert.equal(connection.closeCount, 1);
+    assert.equal(store.closeCount, 1);
+  });
+
+  it("continues cleanup when the unsubscribe fallback throws", async () => {
+    const store = new RecordingStore();
+    const connection = new StalledDrainConnection();
+    connection.failUnsubscribe = true;
+    const agent = newAgent(store, connection);
+    await agent.start();
+
+    await agent.close();
+
+    assert.equal(connection.unsubscribeCount, 1);
+    assert.equal(connection.closeCount, 1);
+    assert.equal(store.closeCount, 1);
+  });
+});

--- a/sdk/node/test/startup-timeout.test.ts
+++ b/sdk/node/test/startup-timeout.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import type { NatsConnection } from "nats";
+import { Agent, InMemoryBlobStore } from "../src/runtime";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve = (_value: T): void => undefined;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(check: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await delay(10);
+  }
+  throw new Error(message);
+}
+
+describe("Agent startup timeout cleanup", () => {
+  it("closes a NATS connection that resolves after the startup timeout", async () => {
+    const pending = deferred<NatsConnection>();
+    let closeCount = 0;
+    const connection = {
+      close: async (): Promise<void> => {
+        closeCount += 1;
+      },
+    } as unknown as NatsConnection;
+    const agent = new Agent({
+      store: new InMemoryBlobStore(),
+      connectFn: async () => pending.promise,
+      ioTimeoutMs: 5,
+    });
+    agent.job("job.startup.timeout", async () => ({}));
+
+    await assert.rejects(agent.start(), /nats connect timed out/);
+    pending.resolve(connection);
+    await waitFor(() => closeCount === 1, "late NATS connection was leaked");
+    await agent.close();
+
+    assert.equal(closeCount, 1);
+  });
+});

--- a/sdk/node/tsconfig.test.json
+++ b/sdk/node/tsconfig.test.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": false,
+    "outDir": ".build",
     "rootDir": "."
   },
   "include": ["src/**/*", "test/**/*"]


### PR DESCRIPTION
## Summary

Repairs the three P0 Node SDK trust failures tracked by `task-de2ef8fbeb5549889bfcb4972ba0efdf`:

- makes the published npm artifact self-contained by bundling the seven canonical CAP schemas and Apache license;
- uses the real NATS v2 `SubscriptionOptions.callback` contract and makes `Agent.close()` wait for intake, in-flight work, result publication, connection drain, and store close;
- centralizes fail-closed inbound validation/signature enforcement for both `startWorker` and `Agent`.

This is a non-wire SDK/runtime bugfix. No protobuf schema or protocol-version change is included.

## Root cause and behavior change

| Boundary | Before | After |
|---|---|---|
| Clean npm install | `loadRoot()` escaped toward repository-relative `proto/` and failed `ENOENT` | packaged `dist/proto/...` is first, with exactly seven canonical schemas |
| NATS dispatch | callback passed as an unsupported third `subscribe` argument | callback is inside NATS v2 subscription options |
| Strict signatures | empty/missing sender paths could bypass low-level verification | any supplied key map, including `{}`, is strict and rejects before handlers |
| Shutdown/startup | callbacks were untracked; duplicate/failed/late starts could leak work/resources | subscriptions and promises are tracked; concurrent close coalesces; late timed-out connects are closed |
| Release | implicit repack could differ from tested bytes | one tgz is packed, integrity-verified, consumer-tested, and published by exact path |

## Verification

| Gate | Evidence |
|---|---|
| Node source | Node 18.20.8, 20.20.2, and 22.23.1: **87 passing, 2 pre-existing pending** on each |
| Installed artifact | Exact tgz passes CJS require, native ESM import, awaited `loadRoot`/`BusPacket` lookup, strict NodeNext consumer types, and strict publint (`All good`) on all three Node versions |
| Artifact contents | 44 entries / 34,206 bytes; exact 7 protos + `LICENSE`; no `src`, `test`, `.build`, or sample output |
| Real NATS | Official nats-server v2.10.25: **1 passing**; submit/result before restart, observed Disconnect/Reconnect on both original connections, second exactly-once result on original worker subscription, bounded cleanup |
| Lifecycle/security | 7 lifecycle/startup tests pass; strict negative matrix passes on both `startWorker` and `Agent`, with zero handler calls/results for denied packets |
| Package/security gates | `npm run build`, `npm run lint:package`, and `npm audit --omit=dev --audit-level=high` pass; production audit reports **0 vulnerabilities** |
| Broader stable SDKs | `go test ./sdk/go/...` passes all six package results; Python suite **90 passed, 2 skipped** |
| Hygiene | `git diff --check` passes; all wholly new handwritten files are <=300 lines and their functions are <=50 lines |

CI now repeats the Node 18/20/22 source/build/installed-package matrix and runs a required non-skipping Docker-backed `nats:2.10.25-alpine` restart job.

## DoD map

1. Clean installed CJS/ESM/loadRoot: covered by the outside-repository exact-tarball verifier and manifest assertions.
2. Real submit/dispatch/result plus shutdown/reconnect: covered by `Node SDK real NATS transport > keeps the original worker subscription after a disconnect and reconnect`.
3. Strict unsigned/missing-sender/unknown/tampered rejection: covered on both public worker surfaces with `{ handlerCalls: 0, resultCount: 0 }` assertions.
4. Source/artifact/publint/types/matrix: green on Node 18/20/22 locally and encoded in CI.

## Explicit follow-ups

- `maxParallel` is advertised but not enforced; a behavioral TCK follow-up is recorded separately and is not claimed fixed here.
- Awaiting an already-running custom heartbeat tick would require an awaitable public stop contract; the current timer-stop caveat is documented rather than hidden in this P0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inbound signature verification with strict security behavior.
  * Node SDK packages now bundle required protocol schemas for runtime use.
  * Improved Node SDK compatibility and build/test workflow for modern Node versions (CommonJS + ESM support).

* **Bug Fixes**
  * Prevented malformed or untrusted inbound messages from reaching job handlers.
  * Improved lifecycle reliability for NATS reconnect/shutdown, including bounded cleanup on startup/shutdown timeouts.
  * Strengthened npm package artifact validation and publish correctness.

* **Documentation**
  * Expanded troubleshooting and SDK documentation for signature verification, protobuf errors, worker routing, heartbeats, and shutdown/ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->