### PR TITLE
[release-truth] address post-merge review comments (injection, panic, errcheck, schema)

### DIFF
--- a/.github/workflows/release-tag-validate.yml
+++ b/.github/workflows/release-tag-validate.yml
@@ -29,9 +29,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Validate release tag (fail-closed)
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${TAG_INPUT:-$REF_NAME}"
           echo "Validating release tag ${TAG}"
 
           # tag == manifest release, source metadata == release, changelog has the entry

--- a/cmd/cap-release/render.go
+++ b/cmd/cap-release/render.go
@@ -116,12 +116,12 @@ func atomicWrite(path, content string) error {
 	}
 	tmp := f.Name()
 	if _, err := f.WriteString(content); err != nil {
-		f.Close()
-		os.Remove(tmp)
+		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmp)
+		_ = os.Remove(tmp)
 		return err
 	}
 	return os.Rename(tmp, path)

--- a/cmd/cap-release/render.go
+++ b/cmd/cap-release/render.go
@@ -66,6 +66,17 @@ func renderAll(m *releasetruth.Manifest, repoRoot string, write bool) int {
 			fmt.Fprintf(os.Stderr, "skip %s: %v\n", t.path, err)
 			continue
 		}
+		if blocks, ferr := releasetruth.FindBlocks(toLF(string(data))); ferr != nil {
+			fmt.Fprintf(os.Stderr, "render %s: %v\n", t.path, ferr)
+			return 1
+		} else if len(blocks) == 0 {
+			// Fail closed: a canonical render target must carry at least one
+			// protected block. Zero blocks means the generated release truth was
+			// deleted from the doc, which CheckDrift alone would pass silently.
+			fmt.Fprintf(os.Stderr, "NO BLOCKS in target %s: expected at least one cap-release block\n", t.path)
+			drift++
+			continue
+		}
 		canonical, drifted, err := releasetruth.CheckDrift(m, string(data))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "render %s: %v\n", t.path, err)

--- a/examples/quickstart-echo/echo.py
+++ b/examples/quickstart-echo/echo.py
@@ -32,8 +32,6 @@ async def main() -> None:
     worker_task = asyncio.create_task(
         worker.run_worker(nats_url=url, subject="sys.job.submit", handler=handle, sender_id="echo-worker")
     )
-    await asyncio.sleep(0.5)  # allow the worker subscription to register
-
     nc = await nats.connect(url)
     fut = asyncio.get_running_loop().create_future()
 
@@ -45,12 +43,22 @@ async def main() -> None:
 
     await nc.subscribe(SUBJECT_RESULT, cb=on_result)
     await nc.flush()
-    await client.submit_job(nc, job_pb2.JobRequest(job_id=JOB_ID, topic="job.echo"), JOB_ID, "echo-client", None)
 
-    try:
-        result = await asyncio.wait_for(fut, timeout=10)
-    except asyncio.TimeoutError:
-        raise SystemExit("timed out waiting for JobResult (no worker?)")
+    # worker.run_worker subscribes on a background task, and core NATS drops a
+    # submit published before that subscription exists. Retry the submit until
+    # the worker answers instead of relying on a fixed startup delay.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10
+    while True:
+        await client.submit_job(
+            nc, job_pb2.JobRequest(job_id=JOB_ID, topic="job.echo"), JOB_ID, "echo-client", None
+        )
+        try:
+            result = await asyncio.wait_for(asyncio.shield(fut), timeout=0.5)
+            break
+        except asyncio.TimeoutError:
+            if loop.time() >= deadline:
+                raise SystemExit("timed out waiting for JobResult (no worker?)")
     if result.status != job_pb2.JOB_STATUS_SUCCEEDED:
         raise SystemExit(f"job {result.job_id} ended {result.status}")
     print(f"job {result.job_id}: SUCCEEDED payload={result.result_ptr}")

--- a/internal/releasetruth/links.go
+++ b/internal/releasetruth/links.go
@@ -75,7 +75,13 @@ func anchorSet(anchors []string) map[string]bool {
 // Line left for the caller to fill) when the link is broken.
 func checkTarget(repoRoot, file, rawTarget string, root RenderRoot, anchors map[string]bool) (LinkProblem, bool) {
 	target := strings.TrimSpace(rawTarget)
-	urlPart := strings.Fields(target)[0] // drop optional "title"
+	fields := strings.Fields(target)
+	if len(fields) == 0 {
+		// A link with an empty or whitespace-only target, e.g. [text]( ), is broken;
+		// report it rather than indexing an empty slice and panicking.
+		return LinkProblem{Target: rawTarget, Reason: "empty link target"}, true
+	}
+	urlPart := fields[0] // drop optional "title"
 	if isExternal(urlPart) {
 		return LinkProblem{}, false
 	}

--- a/internal/releasetruth/links.go
+++ b/internal/releasetruth/links.go
@@ -118,8 +118,14 @@ func resolvePath(repoRoot, file, target, pathPart string, root RenderRoot) (Link
 	if resolved == ".." || strings.HasPrefix(resolved, "../") || path.IsAbs(pathPart) {
 		return LinkProblem{Target: target, Reason: "unsafe: link escapes the repository root"}, true
 	}
-	if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(resolved))); err != nil {
+	full := filepath.Join(repoRoot, filepath.FromSlash(resolved))
+	if _, err := os.Stat(full); err != nil {
 		return LinkProblem{Target: target, Reason: "path not found: " + resolved}, true
+	}
+	// A textually-safe path can still be a symlink escaping the repo; reuse the
+	// spec-path real-path containment so links cannot point outside repoRoot.
+	if ok, err := withinRoot(repoRoot, full); err != nil || !ok {
+		return LinkProblem{Target: target, Reason: "unsafe: link resolves outside the repository root via symlink"}, true
 	}
 	return LinkProblem{}, false
 }

--- a/internal/releasetruth/markdown_test.go
+++ b/internal/releasetruth/markdown_test.go
@@ -71,6 +71,21 @@ func TestCheckLinks_FlagsMissingRepoRelativePathWithLine(t *testing.T) {
 	}
 }
 
+func TestCheckLinks_FlagsWhitespaceOnlyTargetWithoutPanicking(t *testing.T) {
+	root := t.TempDir()
+	doc := strings.Join([]string{
+		"# Doc",
+		"see [here]( ) for details",
+	}, "\n")
+	ps := CheckLinks(root, "README.md", doc, RootNormal)
+	if len(ps) != 1 {
+		t.Fatalf("CheckLinks = %d problems, want 1: %+v", len(ps), ps)
+	}
+	if ps[0].Reason != "empty link target" {
+		t.Errorf("problem reason = %q, want %q", ps[0].Reason, "empty link target")
+	}
+}
+
 func TestCheckLinks_AcceptsExistingRepoRelativePath(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "spec"), 0o755); err != nil {

--- a/internal/releasetruth/quickstart.go
+++ b/internal/releasetruth/quickstart.go
@@ -180,9 +180,17 @@ func checkPythonImports(s Snippet) []ImportProblem {
 		var mod string
 		switch {
 		case strings.HasPrefix(t, "from "):
-			mod = strings.Fields(strings.TrimPrefix(t, "from "))[0]
+			fields := strings.Fields(strings.TrimPrefix(t, "from "))
+			if len(fields) == 0 {
+				continue
+			}
+			mod = fields[0]
 		case strings.HasPrefix(t, "import "):
-			mod = strings.TrimSuffix(strings.Fields(strings.TrimPrefix(t, "import "))[0], ",")
+			fields := strings.Fields(strings.TrimPrefix(t, "import "))
+			if len(fields) == 0 {
+				continue
+			}
+			mod = strings.TrimSuffix(fields[0], ",")
 		default:
 			continue
 		}

--- a/internal/releasetruth/quickstart_test.go
+++ b/internal/releasetruth/quickstart_test.go
@@ -111,6 +111,20 @@ func TestCheckPublicImports_FlagsRelativePythonImport(t *testing.T) {
 	}
 }
 
+func TestCheckPublicImports_PythonHandlesEmptyImportLine(t *testing.T) {
+	// A snippet line that is exactly "from " or "import " with nothing after it
+	// must not panic the checker; the malformed line is skipped.
+	s := Snippet{ID: "py-empty", Language: "python", Code: strings.Join([]string{
+		"import cap",
+		"from ",
+		"import ",
+	}, "\n")}
+	ps := CheckPublicImports(s) // must not panic
+	if len(ps) != 0 {
+		t.Errorf("CheckPublicImports = %+v, want no problems (valid cap import; empty lines skipped)", ps)
+	}
+}
+
 func TestCheckPublicImports_FlagsMissingSDKImport(t *testing.T) {
 	s := Snippet{ID: "go-nosdk", Language: "go", Code: strings.Join([]string{
 		"package main",

--- a/internal/releasetruth/validate.go
+++ b/internal/releasetruth/validate.go
@@ -23,6 +23,7 @@ var (
 // deterministic PR gate.
 func Validate(m *Manifest) []Problem {
 	var ps []Problem
+	ps = append(ps, checkSchema(m)...)
 	ps = append(ps, checkRelease(m)...)
 	ps = append(ps, checkDevelopment(m)...)
 	ps = append(ps, checkWire(m)...)
@@ -33,6 +34,13 @@ func Validate(m *Manifest) []Problem {
 	ps = append(ps, checkSecurity(m)...)
 	ps = append(ps, checkLinks(m)...)
 	return ps
+}
+
+func checkSchema(m *Manifest) []Problem {
+	if !reSemver.MatchString(m.SchemaVersion) {
+		return []Problem{{"schemaVersion", "must be MAJOR.MINOR.PATCH: " + m.SchemaVersion}}
+	}
+	return nil
 }
 
 func checkRelease(m *Manifest) []Problem {

--- a/internal/releasetruth/validate_test.go
+++ b/internal/releasetruth/validate_test.go
@@ -17,6 +17,7 @@ func TestValidate_Rules(t *testing.T) {
 		mutate func(*Manifest)
 		field  string
 	}{
+		{"manifest schema not semver", func(m *Manifest) { m.SchemaVersion = "1.0" }, "schemaVersion"},
 		{"non-semver version", func(m *Manifest) { m.Release.Version = "2.14" }, "release.version"},
 		{"tag not v+version", func(m *Manifest) { m.Release.Tag = "v2.13.0" }, "release.tag"},
 		{"non-iso date", func(m *Manifest) { m.Release.Date = "June 2 2026" }, "release.date"},


### PR DESCRIPTION
Follow-up to **#72** (merged before these fixes landed). Addresses **all 8** review comments left on the merged release-truth code.

### Fixed
| File | Fix | Sev |
|---|---|---|
| `.github/workflows/release-tag-validate.yml` | Map `tag`/`ref` into step `env:` vars instead of interpolating `${{ }}` in the run script — prevents shell command injection. | Major |
| `internal/releasetruth/links.go` (target) | `CheckLinks` no longer panics on a whitespace-only target `[x]( )`; reports `empty link target`. + test. | Major |
| `internal/releasetruth/links.go` (resolvePath) | Reuse `withinRoot()` real-path containment so a link cannot escape `repoRoot` via a symlink. | Minor/sec |
| `internal/releasetruth/quickstart.go` | Guard `from `/`import ` with an empty remainder instead of indexing `Fields(...)[0]` and panicking. + test. | Minor |
| `cmd/cap-release/render.go` | `renderAll` fails closed when a canonical render target has **zero** cap-release blocks (a deleted generated block would otherwise pass the drift gate). | P2 |
| `internal/releasetruth/validate.go` | `cap-release check` validates the manifest's top-level `schemaVersion` is semver (was unchecked). + test. | P2 |
| `cmd/cap-release/render.go` (atomicWrite) | check-mark best-effort `Close`/`Remove` errors (errcheck). | Minor |
| `examples/quickstart-echo/echo.py` | Replace the fixed 0.5s worker-start sleep with a retry-until-answered submit loop — removes the slow-CI race where core NATS drops a submit before the worker subscription exists. | P2 |

### Verification
`go build/vet/test ./internal/releasetruth` green; `cap-release check` / `render --check` / `links` green against the real manifest/docs; `echo.py` `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)