### PR TITLE
release: cut CAP v2.15.0 (handshake + TCK + release-truth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Cordum Agent Protocol and its SDKs are documented her
 
 Entries are grouped by SDK release tag. Wire schema changes (protobuf field additions or semantic changes) are prefixed with **[WIRE]**. See [spec/17-versioning-policy.md](spec/17-versioning-policy.md) for the full versioning policy.
 
-## Unreleased
+## v2.15.0 — 2026-07-20
 
 - Release-truth foundation (not yet released): added `release/manifest.json` as the single machine-readable source of release, wire, SDK, transport, toolchain, and security-support truth; a strict, network-free Go validator (`internal/releasetruth`); and the `cap-release` tool (`check`, `render --write|--check`, `links`). README, the spec index, `SECURITY.md`, and the SDK/transport tables now generate their factual blocks from the manifest.
 - **Go SDK:** `Client.Submit` and package `Submit` now fail fast with `ctx.Err()` before signing or publishing when the context is already canceled or past its deadline (CRD-15). Previously a canceled context still published the job packet.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ flowchart LR
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current release:** 2.15.0 (tag `v2.15.0`, 2026-07-20, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 19 normative documents

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,7 +5,7 @@ Deep technical content for implementers. For an overview, see the [README](../RE
 ## Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current release:** 2.15.0 (tag `v2.15.0`, 2026-07-20, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 19 normative documents

--- a/docs/sdk-comparison.md
+++ b/docs/sdk-comparison.md
@@ -7,10 +7,10 @@ CAP ships three protocol SDKs (Go, Node, Python) that speak directly to the NATS
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.14.0 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.14.0 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.14.0 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.14.0 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.15.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.15.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.15.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.15.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |

--- a/internal/releasetruth/golden_test.go
+++ b/internal/releasetruth/golden_test.go
@@ -35,8 +35,8 @@ func TestGoldenManifest_IsValidAndOnDisk(t *testing.T) {
 	if ps := CheckSpecsOnDisk(m, root); len(ps) != 0 {
 		t.Fatalf("golden manifest specs missing on disk: %v", ps)
 	}
-	if m.Release.Version != "2.14.0" {
-		t.Errorf("golden release version = %q, want 2.14.0", m.Release.Version)
+	if m.Release.Version != "2.15.0" {
+		t.Errorf("golden release version = %q, want 2.15.0", m.Release.Version)
 	}
 	if m.Wire.ProtocolVersion != 1 {
 		t.Errorf("golden wire protocol = %d, want 1", m.Wire.ProtocolVersion)

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -2,15 +2,15 @@
   "$schema": "./manifest.schema.json",
   "schemaVersion": "1.0.0",
   "release": {
-    "version": "2.14.0",
-    "tag": "v2.14.0",
-    "date": "2026-06-02",
-    "commit": "e65a0a8392f552a8e14969a4efb4fe8d4b11a901",
+    "version": "2.15.0",
+    "tag": "v2.15.0",
+    "date": "2026-07-20",
+    "commit": "d8ba96231959a1cea86a13ced4d289e020c7e2db",
     "channel": "stable"
   },
   "development": {
-    "commit": "ed0d8bdcc45a45352a3eaeb612744aaeaf45b96d",
-    "describe": "v2.14.0-8-ged0d8bd",
+    "commit": "d8ba96231959a1cea86a13ced4d289e020c7e2db",
+    "describe": "v2.14.0-14-gd8ba962",
     "released": false
   },
   "wire": {
@@ -49,10 +49,10 @@
       "package": "github.com/cordum-io/cap/v2",
       "registry": "proxy.golang.org",
       "import": "github.com/cordum-io/cap/v2/sdk/go",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "toolchain": "go1.25.12",
       "publication": "published",
-      "evidence": "sdk/go conformance_test.go + CI NATS e2e; released at tag v2.14.0"
+      "evidence": "sdk/go conformance_test.go + CI NATS e2e; released at tag v2.15.0"
     },
     {
       "name": "cap-node",
@@ -62,10 +62,10 @@
       "package": "cap-sdk-node",
       "registry": "registry.npmjs.org",
       "import": "cap-sdk-node",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "toolchain": "node20",
       "publication": "published",
-      "evidence": "CI build+test; released at tag v2.14.0 (source package.json version 2.5.3 is drift, reconciled separately)"
+      "evidence": "CI build+test; released at tag v2.15.0"
     },
     {
       "name": "cap-python",
@@ -75,10 +75,10 @@
       "package": "cap-sdk-python",
       "registry": "pypi.org",
       "import": "cap-sdk-python",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "toolchain": "python3.11",
       "publication": "published",
-      "evidence": "CI pytest; released at tag v2.14.0 (source pyproject version 2.5.3 is drift, reconciled separately)"
+      "evidence": "CI pytest; released at tag v2.15.0"
     },
     {
       "name": "cordum-guard",
@@ -88,10 +88,10 @@
       "package": "cordum-guard",
       "registry": "pypi.org",
       "import": "cordum-guard",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "toolchain": "python3.11",
       "publication": "published",
-      "evidence": "unit tests; published on PyPI on the release train (latest 2.14.0). Source pyproject carries an in-development version (0.1.0) that is drift and must not be treated as the published artifact."
+      "evidence": "unit tests; published on PyPI on the release train (latest 2.15.0). Source pyproject carries an in-development 2.15.0 prerelease that must not be treated as the published artifact."
     },
     { "name": "cap-cpp", "kind": "sdk", "tier": "experimental", "language": "cpp", "package": "", "registry": "", "import": "", "version": "", "toolchain": "", "publication": "source-only", "evidence": "" },
     { "name": "cap-dotnet", "kind": "sdk", "tier": "experimental", "language": "dotnet", "package": "", "registry": "", "import": "", "version": "", "toolchain": "", "publication": "source-only", "evidence": "" },

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -7,10 +7,10 @@ This folder contains SDKs for CAP.
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.14.0 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.14.0 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.14.0 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.14.0 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.15.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.15.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.15.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.15.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |

--- a/spec/00-index.md
+++ b/spec/00-index.md
@@ -18,7 +18,7 @@ Tags: `conformance`, `fixtures`, `testing`, `signing`, `deterministic`.
 - Repository/SDK releases track implementation and are pinned by tag for reproducibility.
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current release:** 2.15.0 (tag `v2.15.0`, 2026-07-20, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 19 normative documents

--- a/spec/17-versioning-policy.md
+++ b/spec/17-versioning-policy.md
@@ -16,7 +16,7 @@ The `protocol_version` field in `BusPacket` carries the wire version as a positi
 
 <!-- cap-release:begin:version-policy -->
 - **Wire protocol version:** 1. Wire evolution is append-only within the compatible range 1–1.
-- **Current published release:** 2.14.0 (tag `v2.14.0`). SDK and repository releases track implementation and are pinned by tag.
+- **Current published release:** 2.15.0 (tag `v2.15.0`). SDK and repository releases track implementation and are pinned by tag.
 - **Source versus release:** development source may carry an in-progress version distinct from the latest published artifact; the release manifest is the authority on what is published.
 <!-- cap-release:end -->
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -17,7 +17,7 @@ This wiki provides a comprehensive guide to understanding, using, and contributi
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current release:** 2.15.0 (tag `v2.15.0`, 2026-07-20, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 19 normative documents
@@ -28,10 +28,10 @@ This wiki provides a comprehensive guide to understanding, using, and contributi
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.14.0 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.14.0 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.14.0 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.14.0 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.15.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.15.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.15.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.15.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |


### PR DESCRIPTION
## What
Cuts **CAP v2.15.0** — the first release carrying the authenticated worker-trust **handshake** (#69), the behavioral **TCK** + evidence-backed SDK tiers (#71), and the **release-truth** manifest system (#72), on top of the v2.14.0 line.

- `release/manifest.json`: `release` + all 4 stable component versions 2.14.0 → **2.15.0**; `development` snapshot refreshed to current main (`d8ba962`, `v2.14.0-14-gd8ba962`); evidence strings refreshed.
- `CHANGELOG.md`: `## Unreleased` → `## v2.15.0 — 2026-07-20`.
- Regenerated manifest-driven doc blocks: README, docs/reference, docs/sdk-comparison, sdk/README, spec/00-index, spec/17-versioning-policy, wiki/Home.
- `golden_test.go`: golden release-version assertion → 2.15.0.

## Validated (every gate release-truth.yml runs on main)
```
cap-release check            OK: v2.15.0 (wire 1), 19 specs, 10 components
cap-release render --check   all files in sync
cap-release links            all internal links and anchors resolve
go test ./internal/releasetruth/... ./cmd/cap-release/...   ok
```

## Source stays 2.15.0-dev here — by design
The main invariant (`development.released=false`) requires each SDK's **source** version to be a dev/prerelease marker distinct from the published release (`TestSourceMetadata_NotStampedAsRelease`). So `sdk/node`=2.15.0-dev.0 and `sdk/python`+`guard`=2.15.0.dev0 are unchanged in this PR. `release-check --tag` correctly reports source≠release until the tag step.

## Final tag step (atomic, human-gated — triggers publish)
After merge, on a release commit:
1. Strip `-dev`: `sdk/node/package.json`, `sdk/python/pyproject.toml`, `sdk/python-guard/pyproject.toml` → `2.15.0`.
2. Set `release.commit` to that commit's SHA (per `release-tag-validate.yml` tag-target==SHA).
3. `go run ./cmd/cap-release release-check --tag v2.15.0` → must pass.
4. `git tag v2.15.0 && git push origin v2.15.0` → triggers `release-tag-validate.yml` + publish (npm / PyPI / Go proxy).
5. Bump source to `2.16.0-dev` for the next cycle.

## Note on scope/timing
This ships handshake + TCK + release-truth. **CAP-PRODUCTION (a13f83fa) is NOT in this release** (still in progress). If you'd rather ship the full hardened protocol in one release, hold the tag until CAP-PRODUCTION lands and re-cut. Tagging this unblocks the Cordum integration capstone immediately (it needs a handshake-bearing released tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Published stable version **2.15.0** on **July 20, 2026**.
  - Updated release metadata and SDK version references across project documentation.

- **Documentation**
  - Refreshed release status, versioning guidance, SDK comparison tables, and onboarding references.
  - Updated supported versions for Go, Node, Python, and Cordum Guard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->