### PR TITLE
fix(release): add truthful tag snapshot state

### DIFF
--- a/.github/workflows/release-tag-validate.yml
+++ b/.github/workflows/release-tag-validate.yml
@@ -37,7 +37,8 @@ jobs:
           TAG="${TAG_INPUT:-$REF_NAME}"
           echo "Validating release tag ${TAG}"
 
-          # tag == manifest release, source metadata == release, changelog has the entry
+          # tag == prepared candidate when present (otherwise published release),
+          # source metadata == selected target, changelog has the entry
           go run ./cmd/cap-release release-check --manifest release/manifest.json --repo-root . --tag "${TAG}"
 
           # manifest is internally valid and specs are on disk

--- a/.github/workflows/release-tag-validate.yml
+++ b/.github/workflows/release-tag-validate.yml
@@ -37,8 +37,9 @@ jobs:
           TAG="${TAG_INPUT:-$REF_NAME}"
           echo "Validating release tag ${TAG}"
 
-          # tag == prepared candidate when present (otherwise published release),
-          # source metadata == selected target, changelog has the entry
+          # tag == prepared immutable snapshot when present (otherwise an
+          # already-published release), source metadata == selected target,
+          # changelog has the entry. A mutable candidate cannot pass this gate.
           go run ./cmd/cap-release release-check --manifest release/manifest.json --repo-root . --tag "${TAG}"
 
           # manifest is internally valid and specs are on disk

--- a/.github/workflows/release-truth.yml
+++ b/.github/workflows/release-truth.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # promotion-check resolves the manifest's published tag locally and
+          # proves it is an ancestor of the reviewed tree. The command itself
+          # never fetches or contacts a registry.
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
@@ -29,6 +34,8 @@ jobs:
           if [ -n "$out" ]; then echo "gofmt needed:"; echo "$out"; exit 1; fi
       - name: Manifest check (schema, rules, specs on disk)
         run: go run ./cmd/cap-release check --manifest release/manifest.json --repo-root .
+      - name: Published release provenance (tag target and changelog date)
+        run: go run ./cmd/cap-release promotion-check --manifest release/manifest.json --repo-root .
       - name: Docs render drift (generated blocks must match the manifest)
         run: go run ./cmd/cap-release render --manifest release/manifest.json --repo-root . --check
       - name: Internal links and anchors (mandatory)

--- a/.github/workflows/release-truth.yml
+++ b/.github/workflows/release-truth.yml
@@ -23,6 +23,7 @@ jobs:
           # proves it is an ancestor of the reviewed tree. The command itself
           # never fetches or contacts a registry.
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ flowchart LR
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current verified published release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents

--- a/cmd/cap-release/main.go
+++ b/cmd/cap-release/main.go
@@ -50,6 +50,7 @@ func runCheck(args []string) int {
 	}
 	problems := releasetruth.Validate(m)
 	problems = append(problems, releasetruth.CheckSpecsOnDisk(m, *repoRoot)...)
+	problems = append(problems, releasetruth.CheckSourceMetadata(m, *repoRoot)...)
 	if len(problems) > 0 {
 		fmt.Fprintf(os.Stderr, "release-truth check FAILED: %d problem(s)\n", len(problems))
 		for _, p := range problems {

--- a/cmd/cap-release/main.go
+++ b/cmd/cap-release/main.go
@@ -18,7 +18,7 @@ func main() {
 
 func run(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: cap-release <check|render|links> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: cap-release <check|render|links|release-check|promotion-check> [flags]")
 		return 2
 	}
 	switch args[0] {
@@ -30,8 +30,10 @@ func run(args []string) int {
 		return runLinks(args[1:])
 	case "release-check":
 		return runReleaseCheck(args[1:])
+	case "promotion-check":
+		return runPromotionCheck(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown subcommand %q (supported: check, render, links, release-check)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q (supported: check, render, links, release-check, promotion-check)\n", args[0])
 		return 2
 	}
 }

--- a/cmd/cap-release/promotioncheck.go
+++ b/cmd/cap-release/promotioncheck.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cordum-io/cap/v2/internal/releasetruth"
+)
+
+func runPromotionCheck(args []string) int {
+	fs := flag.NewFlagSet("promotion-check", flag.ContinueOnError)
+	manifestPath := fs.String("manifest", "release/manifest.json", "path to the release manifest")
+	repoRoot := fs.String("repo-root", ".", "repository root with fetched release tags")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	m, err := releasetruth.LoadFile(*manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load: %v\n", err)
+		return 1
+	}
+	commit, err := resolveLocalTagCommit(*repoRoot, m.Release.Tag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "promotion-check: %v\n", err)
+		return 1
+	}
+	problems := releasetruth.PromotionCheck(m, *repoRoot, commit)
+	if len(problems) > 0 {
+		fmt.Fprintf(os.Stderr, "promotion-check FAILED: %d problem(s)\n", len(problems))
+		for _, problem := range problems {
+			fmt.Fprintf(os.Stderr, "  - %s\n", problem.Error())
+		}
+		return 1
+	}
+	fmt.Printf("promotion-check OK: %s resolves to %s with bound release metadata\n", m.Release.Tag, commit)
+	return 0
+}
+
+func resolveLocalTagCommit(repoRoot, tag string) (string, error) {
+	ref := "refs/tags/" + tag + "^{commit}"
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", ref)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolve tag %s: %w: %s", tag, err, strings.TrimSpace(string(out)))
+	}
+	commit := strings.TrimSpace(string(out))
+	cmd = exec.Command("git", "-C", repoRoot, "merge-base", "--is-ancestor", commit, "HEAD")
+	if out, err = cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("tag %s target %s is not an ancestor of HEAD: %w: %s", tag, commit, err, strings.TrimSpace(string(out)))
+	}
+	return commit, nil
+}

--- a/cmd/cap-release/promotioncheck.go
+++ b/cmd/cap-release/promotioncheck.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/cordum-io/cap/v2/internal/releasetruth"
 )
+
+const promotionGitTimeout = 10 * time.Second
 
 func runPromotionCheck(args []string) int {
 	fs := flag.NewFlagSet("promotion-check", flag.ContinueOnError)
@@ -40,14 +44,20 @@ func runPromotionCheck(args []string) int {
 }
 
 func resolveLocalTagCommit(repoRoot, tag string) (string, error) {
+	return resolveLocalTagCommitWithin(repoRoot, tag, promotionGitTimeout)
+}
+
+func resolveLocalTagCommitWithin(repoRoot, tag string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	ref := "refs/tags/" + tag + "^{commit}"
-	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", ref)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--verify", ref)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("resolve tag %s: %w: %s", tag, err, strings.TrimSpace(string(out)))
 	}
 	commit := strings.TrimSpace(string(out))
-	cmd = exec.Command("git", "-C", repoRoot, "merge-base", "--is-ancestor", commit, "HEAD")
+	cmd = exec.CommandContext(ctx, "git", "-C", repoRoot, "merge-base", "--is-ancestor", commit, "HEAD")
 	if out, err = cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("tag %s target %s is not an ancestor of HEAD: %w: %s", tag, commit, err, strings.TrimSpace(string(out)))
 	}

--- a/cmd/cap-release/promotioncheck_test.go
+++ b/cmd/cap-release/promotioncheck_test.go
@@ -34,6 +34,14 @@ func TestResolveLocalTagCommit_RequiresAncestorOfHead(t *testing.T) {
 	}
 }
 
+func TestResolveLocalTagCommit_TimesOut(t *testing.T) {
+	repo := t.TempDir()
+	gitForTest(t, repo, "init", "-b", "main")
+	if _, err := resolveLocalTagCommitWithin(repo, "v2.15.0", 0); err == nil {
+		t.Fatal("resolveLocalTagCommitWithin() error = nil, want timeout")
+	}
+}
+
 func TestReleaseTruthWorkflowRunsPromotionCheckWithTags(t *testing.T) {
 	path := filepath.Join("..", "..", ".github", "workflows", "release-truth.yml")
 	data, err := os.ReadFile(path)
@@ -41,7 +49,7 @@ func TestReleaseTruthWorkflowRunsPromotionCheckWithTags(t *testing.T) {
 		t.Fatal(err)
 	}
 	workflow := string(data)
-	for _, want := range []string{"fetch-depth: 0", "cap-release promotion-check"} {
+	for _, want := range []string{"fetch-depth: 0", "persist-credentials: false", "cap-release promotion-check"} {
 		if !strings.Contains(workflow, want) {
 			t.Fatalf("release-truth workflow lacks %q", want)
 		}

--- a/cmd/cap-release/promotioncheck_test.go
+++ b/cmd/cap-release/promotioncheck_test.go
@@ -17,7 +17,11 @@ func TestResolveLocalTagCommit_RequiresAncestorOfHead(t *testing.T) {
 	first := gitForTest(t, repo, "rev-parse", "HEAD")
 	writeGitFixture(t, repo, "two")
 	second := gitForTest(t, repo, "rev-parse", "HEAD")
-	gitForTest(t, repo, "tag", "v2.15.0")
+	gitForTest(t, repo, "tag", "-a", "v2.15.0", "-m", "release fixture")
+	tagObject := gitForTest(t, repo, "rev-parse", "refs/tags/v2.15.0")
+	if tagObject == second {
+		t.Fatal("fixture tag is not annotated")
+	}
 
 	got, err := resolveLocalTagCommit(repo, "v2.15.0")
 	if err != nil || got != second {

--- a/cmd/cap-release/promotioncheck_test.go
+++ b/cmd/cap-release/promotioncheck_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveLocalTagCommit_RequiresAncestorOfHead(t *testing.T) {
+	repo := t.TempDir()
+	gitForTest(t, repo, "init", "-b", "main")
+	gitForTest(t, repo, "config", "user.email", "release-test@example.com")
+	gitForTest(t, repo, "config", "user.name", "Release Test")
+	writeGitFixture(t, repo, "one")
+	first := gitForTest(t, repo, "rev-parse", "HEAD")
+	writeGitFixture(t, repo, "two")
+	second := gitForTest(t, repo, "rev-parse", "HEAD")
+	gitForTest(t, repo, "tag", "v2.15.0")
+
+	got, err := resolveLocalTagCommit(repo, "v2.15.0")
+	if err != nil || got != second {
+		t.Fatalf("resolveLocalTagCommit() = %q, %v; want %q, nil", got, err, second)
+	}
+
+	gitForTest(t, repo, "checkout", "--detach", first)
+	if _, err := resolveLocalTagCommit(repo, "v2.15.0"); err == nil || !strings.Contains(err.Error(), "not an ancestor") {
+		t.Fatalf("resolveLocalTagCommit(non-ancestor) error = %v, want not-an-ancestor error", err)
+	}
+}
+
+func TestReleaseTruthWorkflowRunsPromotionCheckWithTags(t *testing.T) {
+	path := filepath.Join("..", "..", ".github", "workflows", "release-truth.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, want := range []string{"fetch-depth: 0", "cap-release promotion-check"} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("release-truth workflow lacks %q", want)
+		}
+	}
+}
+
+func writeGitFixture(t *testing.T, repo, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "fixture.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitForTest(t, repo, "add", "fixture.txt")
+	gitForTest(t, repo, "commit", "-m", content)
+}
+
+func gitForTest(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,7 +5,7 @@ Deep technical content for implementers. For an overview, see the [README](../RE
 ## Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current verified published release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents

--- a/internal/releasetruth/blocks.go
+++ b/internal/releasetruth/blocks.go
@@ -68,6 +68,10 @@ func renderReleaseStatus(m *Manifest) string {
 		fmt.Sprintf("- **Wire schema:** %s", w.SchemaVersion),
 		fmt.Sprintf("- **Specifications:** %d normative documents", len(m.Specs)),
 	}
+	if m.Candidate != nil {
+		lines = append(lines, fmt.Sprintf("- **Release candidate (not published):** %s (tag `%s`, channel %s)",
+			m.Candidate.Version, m.Candidate.Tag, m.Candidate.Channel))
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -99,6 +103,10 @@ func renderVersionPolicy(m *Manifest) string {
 		fmt.Sprintf("- **Wire protocol version:** %d. Wire evolution is append-only within the compatible range %d–%d.", w.ProtocolVersion, w.CompatMin, w.CompatMax),
 		fmt.Sprintf("- **Current published release:** %s (tag `%s`). SDK and repository releases track implementation and are pinned by tag.", r.Version, r.Tag),
 		"- **Source versus release:** development source may carry an in-progress version distinct from the latest published artifact; the release manifest is the authority on what is published.",
+	}
+	if m.Candidate != nil {
+		lines = append(lines, fmt.Sprintf("- **Release candidate (not published):** %s (tag `%s`, channel %s).",
+			m.Candidate.Version, m.Candidate.Tag, m.Candidate.Channel))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/releasetruth/blocks.go
+++ b/internal/releasetruth/blocks.go
@@ -63,7 +63,7 @@ func renderSpecTOC(m *Manifest) string {
 func renderReleaseStatus(m *Manifest) string {
 	r, w := m.Release, m.Wire
 	lines := []string{
-		fmt.Sprintf("- **Current release:** %s (tag `%s`, %s, channel %s)", r.Version, r.Tag, r.Date, r.Channel),
+		fmt.Sprintf("- **Current verified published release:** %s (tag `%s`, %s, channel %s)", r.Version, r.Tag, r.Date, r.Channel),
 		fmt.Sprintf("- **Wire protocol:** %d (compatible range %d–%d)", w.ProtocolVersion, w.CompatMin, w.CompatMax),
 		fmt.Sprintf("- **Wire schema:** %s", w.SchemaVersion),
 		fmt.Sprintf("- **Specifications:** %d normative documents", len(m.Specs)),
@@ -71,6 +71,9 @@ func renderReleaseStatus(m *Manifest) string {
 	if m.Candidate != nil {
 		lines = append(lines, fmt.Sprintf("- **Release candidate (not published):** %s (tag `%s`, channel %s)",
 			m.Candidate.Version, m.Candidate.Tag, m.Candidate.Channel))
+	}
+	if m.Snapshot != nil {
+		lines = append(lines, renderSnapshotStatus(m.Snapshot))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -108,7 +111,15 @@ func renderVersionPolicy(m *Manifest) string {
 		lines = append(lines, fmt.Sprintf("- **Release candidate (not published):** %s (tag `%s`, channel %s).",
 			m.Candidate.Version, m.Candidate.Tag, m.Candidate.Channel))
 	}
+	if m.Snapshot != nil {
+		lines = append(lines, renderSnapshotStatus(m.Snapshot))
+	}
 	return strings.Join(lines, "\n")
+}
+
+func renderSnapshotStatus(snapshot *Snapshot) string {
+	return fmt.Sprintf("- **Prepared release snapshot:** %s (tag `%s`, channel %s); publication status is not asserted by this source state.",
+		snapshot.Version, snapshot.Tag, snapshot.Channel)
 }
 
 func renderSecurityLines(m *Manifest) string {

--- a/internal/releasetruth/candidate_test.go
+++ b/internal/releasetruth/candidate_test.go
@@ -81,11 +81,11 @@ func TestCheckSourceMetadata_RejectsStableVersionWithoutCandidate(t *testing.T) 
 	}
 }
 
-func TestReleaseCheck_UsesCandidateAndKeepsPublishedReleaseDistinct(t *testing.T) {
+func TestReleaseCheck_CandidateCannotBeTagged(t *testing.T) {
 	m := validCandidateManifest()
 	root := writeReleaseTree(t, m.Candidate.Version, m.Candidate.Tag)
-	if ps := ReleaseCheck(m, root, m.Candidate.Tag); len(ps) != 0 {
-		t.Fatalf("ReleaseCheck(candidate) = %v, want none", ps)
+	if ps := ReleaseCheck(m, root, m.Candidate.Tag); !hasField(ps, "snapshot.required") {
+		t.Fatalf("ReleaseCheck(candidate) = %v, want snapshot.required", ps)
 	}
 	if m.Release.Version != "2.14.0" {
 		t.Fatalf("published release mutated to %q", m.Release.Version)

--- a/internal/releasetruth/candidate_test.go
+++ b/internal/releasetruth/candidate_test.go
@@ -1,0 +1,109 @@
+package releasetruth
+
+import (
+	"strings"
+	"testing"
+)
+
+func validCandidateManifest() *Manifest {
+	m := validManifest()
+	m.Candidate = &Candidate{
+		Version: "2.15.0",
+		Tag:     "v2.15.0",
+		Channel: "stable",
+	}
+	return m
+}
+
+func TestValidate_CandidateRules(t *testing.T) {
+	if ps := Validate(validCandidateManifest()); len(ps) != 0 {
+		t.Fatalf("Validate(valid candidate) = %v, want none", ps)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Manifest)
+		field  string
+	}{
+		{"non-semver version", func(m *Manifest) { m.Candidate.Version = "2.15" }, "candidate.version"},
+		{"tag not v+version", func(m *Manifest) { m.Candidate.Tag = "v2.15.1" }, "candidate.tag"},
+		{"same as published release", func(m *Manifest) { m.Candidate.Version = "2.14.0"; m.Candidate.Tag = "v2.14.0" }, "candidate.version"},
+		{"older than published release", func(m *Manifest) { m.Candidate.Version = "2.13.0"; m.Candidate.Tag = "v2.13.0" }, "candidate.version"},
+		{"unknown channel", func(m *Manifest) { m.Candidate.Channel = "prod" }, "candidate.channel"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validCandidateManifest()
+			tc.mutate(m)
+			if ps := Validate(m); !hasField(ps, tc.field) {
+				t.Fatalf("Validate(candidate) = %v, want field %q", ps, tc.field)
+			}
+		})
+	}
+}
+
+func TestValidate_CandidateVersionComparisonDoesNotOverflow(t *testing.T) {
+	m := validCandidateManifest()
+	m.Release.Version = "999999999999999999999999999998.0.0"
+	m.Release.Tag = "v" + m.Release.Version
+	m.Candidate.Version = "999999999999999999999999999999.0.0"
+	m.Candidate.Tag = "v" + m.Candidate.Version
+	if ps := Validate(m); hasField(ps, "candidate.version") {
+		t.Fatalf("Validate(large newer candidate) = %v, want no candidate.version problem", ps)
+	}
+}
+
+func TestLoad_Candidate(t *testing.T) {
+	want := validCandidateManifest()
+	b := mustMarshalManifest(t, want)
+	got, err := Load(b)
+	if err != nil {
+		t.Fatalf("Load(candidate) error: %v", err)
+	}
+	if got.Candidate == nil || *got.Candidate != *want.Candidate {
+		t.Fatalf("Load(candidate) = %#v, want %#v", got.Candidate, want.Candidate)
+	}
+}
+
+func TestCheckSourceMetadata_AllowsExactCandidateVersion(t *testing.T) {
+	m := validCandidateManifest()
+	root := writeReleaseTree(t, m.Candidate.Version, m.Candidate.Tag)
+	if ps := CheckSourceMetadata(m, root); len(ps) != 0 {
+		t.Fatalf("CheckSourceMetadata(candidate) = %v, want none", ps)
+	}
+}
+
+func TestCheckSourceMetadata_RejectsStableVersionWithoutCandidate(t *testing.T) {
+	m := validManifest()
+	root := writeReleaseTree(t, "2.15.0", "v2.15.0")
+	if ps := CheckSourceMetadata(m, root); !hasField(ps, "development.source.version") {
+		t.Fatalf("CheckSourceMetadata(stable development) = %v, want development.source.version", ps)
+	}
+}
+
+func TestReleaseCheck_UsesCandidateAndKeepsPublishedReleaseDistinct(t *testing.T) {
+	m := validCandidateManifest()
+	root := writeReleaseTree(t, m.Candidate.Version, m.Candidate.Tag)
+	if ps := ReleaseCheck(m, root, m.Candidate.Tag); len(ps) != 0 {
+		t.Fatalf("ReleaseCheck(candidate) = %v, want none", ps)
+	}
+	if m.Release.Version != "2.14.0" {
+		t.Fatalf("published release mutated to %q", m.Release.Version)
+	}
+}
+
+func TestRenderBlock_LabelsCandidateAsNotPublished(t *testing.T) {
+	m := validCandidateManifest()
+	for _, id := range []string{"release-status", "version-policy"} {
+		got, err := RenderBlock(m, id)
+		if err != nil {
+			t.Fatalf("RenderBlock(%s) error: %v", id, err)
+		}
+		if !strings.Contains(got, "2.14.0") || !strings.Contains(got, "2.15.0") {
+			t.Fatalf("RenderBlock(%s) = %q, want published and candidate versions", id, got)
+		}
+		if !strings.Contains(strings.ToLower(got), "candidate") || !strings.Contains(strings.ToLower(got), "not published") {
+			t.Fatalf("RenderBlock(%s) = %q, want explicit candidate/not-published label", id, got)
+		}
+	}
+}

--- a/internal/releasetruth/candidate_test.go
+++ b/internal/releasetruth/candidate_test.go
@@ -84,8 +84,12 @@ func TestCheckSourceMetadata_RejectsStableVersionWithoutCandidate(t *testing.T) 
 func TestReleaseCheck_CandidateCannotBeTagged(t *testing.T) {
 	m := validCandidateManifest()
 	root := writeReleaseTree(t, m.Candidate.Version, m.Candidate.Tag)
-	if ps := ReleaseCheck(m, root, m.Candidate.Tag); !hasField(ps, "snapshot.required") {
+	ps := ReleaseCheck(m, root, m.Candidate.Tag)
+	if !hasField(ps, "snapshot.required") {
 		t.Fatalf("ReleaseCheck(candidate) = %v, want snapshot.required", ps)
+	}
+	if len(ps) != 1 {
+		t.Fatalf("ReleaseCheck(candidate) = %v, want only snapshot.required", ps)
 	}
 	if m.Release.Version != "2.14.0" {
 		t.Fatalf("published release mutated to %q", m.Release.Version)

--- a/internal/releasetruth/helpers_test.go
+++ b/internal/releasetruth/helpers_test.go
@@ -11,7 +11,7 @@ import (
 // release truth at origin/main@ed0d8bd (v2.14.0).
 func validManifest() *Manifest {
 	return &Manifest{
-		SchemaVersion: "1.1.0",
+		SchemaVersion: "1.2.0",
 		Release: Release{
 			Version: "2.14.0",
 			Tag:     "v2.14.0",

--- a/internal/releasetruth/helpers_test.go
+++ b/internal/releasetruth/helpers_test.go
@@ -11,7 +11,7 @@ import (
 // release truth at origin/main@ed0d8bd (v2.14.0).
 func validManifest() *Manifest {
 	return &Manifest{
-		SchemaVersion: "1.0.0",
+		SchemaVersion: "1.1.0",
 		Release: Release{
 			Version: "2.14.0",
 			Tag:     "v2.14.0",
@@ -74,7 +74,12 @@ func guardComponent() Component {
 // exercise the real strict parser rather than a hand-maintained literal.
 func validManifestJSON(t *testing.T) []byte {
 	t.Helper()
-	b, err := json.Marshal(validManifest())
+	return mustMarshalManifest(t, validManifest())
+}
+
+func mustMarshalManifest(t *testing.T, m *Manifest) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
 	if err != nil {
 		t.Fatalf("marshal baseline manifest: %v", err)
 	}

--- a/internal/releasetruth/manifest.go
+++ b/internal/releasetruth/manifest.go
@@ -1,6 +1,6 @@
 // Package releasetruth defines the canonical machine-readable release manifest
 // for CAP and a strict, network-free parser and validator. The manifest is the
-// single hand-edited source of current release, future candidate, wire, SDK, transport,
+// single hand-edited source of published release, candidate, snapshot, wire, SDK, transport,
 // toolchain, and security-support truth; docs and CI derive from it rather than
 // maintaining parallel matrices that drift.
 package releasetruth
@@ -18,6 +18,7 @@ type Manifest struct {
 	SchemaVersion string      `json:"schemaVersion"`
 	Release       Release     `json:"release"`
 	Candidate     *Candidate  `json:"candidate,omitempty"`
+	Snapshot      *Snapshot   `json:"snapshot,omitempty"`
 	Development   Development `json:"development"`
 	Wire          Wire        `json:"wire"`
 	Specs         []Spec      `json:"specs"`
@@ -37,10 +38,19 @@ type Release struct {
 	Channel string `json:"channel"`
 }
 
-// Candidate identifies source prepared for a future release without
-// relabelling it as the latest published artifact. Its immutable target SHA is
-// bound by the tag workflow after the candidate commit reaches main.
+// Candidate identifies mutable source prepared for a future release without
+// relabelling it as the latest published artifact. It cannot pass the tag gate;
+// exact source must first be frozen into Snapshot.
 type Candidate struct {
+	Version string `json:"version"`
+	Tag     string `json:"tag"`
+	Channel string `json:"channel"`
+}
+
+// Snapshot identifies the exact source state intended for an immutable tag.
+// Presence does not assert that the tag or any registry artifact exists. The
+// containing commit SHA, together with Tag, is the human approval boundary.
+type Snapshot struct {
 	Version string `json:"version"`
 	Tag     string `json:"tag"`
 	Channel string `json:"channel"`

--- a/internal/releasetruth/manifest.go
+++ b/internal/releasetruth/manifest.go
@@ -1,6 +1,6 @@
 // Package releasetruth defines the canonical machine-readable release manifest
 // for CAP and a strict, network-free parser and validator. The manifest is the
-// single hand-edited source of current release, wire, SDK, transport,
+// single hand-edited source of current release, future candidate, wire, SDK, transport,
 // toolchain, and security-support truth; docs and CI derive from it rather than
 // maintaining parallel matrices that drift.
 package releasetruth
@@ -17,6 +17,7 @@ type Manifest struct {
 	Schema        string      `json:"$schema,omitempty"`
 	SchemaVersion string      `json:"schemaVersion"`
 	Release       Release     `json:"release"`
+	Candidate     *Candidate  `json:"candidate,omitempty"`
 	Development   Development `json:"development"`
 	Wire          Wire        `json:"wire"`
 	Specs         []Spec      `json:"specs"`
@@ -33,6 +34,15 @@ type Release struct {
 	Tag     string `json:"tag"`
 	Date    string `json:"date"`
 	Commit  string `json:"commit"`
+	Channel string `json:"channel"`
+}
+
+// Candidate identifies source prepared for a future release without
+// relabelling it as the latest published artifact. Its immutable target SHA is
+// bound by the tag workflow after the candidate commit reaches main.
+type Candidate struct {
+	Version string `json:"version"`
+	Tag     string `json:"tag"`
 	Channel string `json:"channel"`
 }
 

--- a/internal/releasetruth/metadata_test.go
+++ b/internal/releasetruth/metadata_test.go
@@ -1,49 +1,13 @@
 package releasetruth
 
-import (
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
-)
+import "testing"
 
 // TestSourceMetadata_NotStampedAsRelease guards the supply-chain reproducibility
-// invariant: while the manifest marks the tree as unreleased development
-// (development.released=false), each stable package's SOURCE version must be a
-// development/prerelease marker distinct from the published release artifact, so
-// changed source is never mistaken for the already-published version.
+// invariant: source is either a development marker or exactly the explicit
+// future candidate, and is never mistaken for the already-published version.
 func TestSourceMetadata_NotStampedAsRelease(t *testing.T) {
 	m, root := loadGolden(t)
-	if m.Development.Released {
-		t.Skip("development.released=true: source==release is expected only at release prep")
-	}
-	cases := []struct {
-		file string
-		re   *regexp.Regexp
-	}{
-		{"sdk/node/package.json", regexp.MustCompile(`"version"\s*:\s*"([^"]+)"`)},
-		{"sdk/python/pyproject.toml", regexp.MustCompile(`(?m)^version\s*=\s*"([^"]+)"`)},
-		{"sdk/python-guard/pyproject.toml", regexp.MustCompile(`(?m)^version\s*=\s*"([^"]+)"`)},
-	}
-	for _, c := range cases {
-		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(c.file)))
-		if err != nil {
-			t.Errorf("read %s: %v", c.file, err)
-			continue
-		}
-		match := c.re.FindStringSubmatch(string(data))
-		if match == nil {
-			t.Errorf("%s: no version found", c.file)
-			continue
-		}
-		v := match[1]
-		if v == m.Release.Version {
-			t.Errorf("%s version %q equals the published release %q; development source must not be stamped as the released artifact",
-				c.file, v, m.Release.Version)
-		}
-		if !strings.Contains(v, "dev") && !strings.Contains(v, "-") {
-			t.Errorf("%s version %q is not a development/prerelease marker while development.released=false", c.file, v)
-		}
+	if ps := CheckSourceMetadata(m, root); len(ps) != 0 {
+		t.Fatalf("source metadata is inconsistent with manifest state: %v", ps)
 	}
 }

--- a/internal/releasetruth/promotion.go
+++ b/internal/releasetruth/promotion.go
@@ -1,0 +1,45 @@
+package releasetruth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// PromotionCheck binds the latest verified published release metadata to the
+// already-resolved immutable tag target and its dated changelog entry.
+func PromotionCheck(m *Manifest, repoRoot, resolvedTagCommit string) []Problem {
+	ps := Validate(m)
+	resolved := strings.TrimSpace(resolvedTagCommit)
+	if resolved != m.Release.Commit {
+		ps = append(ps, Problem{
+			"release.commit.tagTarget",
+			fmt.Sprintf("release tag %s resolves to %q, not manifest commit %q", m.Release.Tag, resolved, m.Release.Commit),
+		})
+	}
+	date, err := readChangelogReleaseDate(repoRoot, m.Release.Tag)
+	if err != nil {
+		ps = append(ps, Problem{"release.date.changelog", err.Error()})
+	} else if date != m.Release.Date {
+		ps = append(ps, Problem{
+			"release.date.changelog",
+			fmt.Sprintf("release date %q does not match changelog date %q", m.Release.Date, date),
+		})
+	}
+	return ps
+}
+
+func readChangelogReleaseDate(repoRoot, tag string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, "CHANGELOG.md"))
+	if err != nil {
+		return "", fmt.Errorf("read CHANGELOG.md: %w", err)
+	}
+	pattern := `(?m)^##[ \t]+` + regexp.QuoteMeta(tag) + `[ \t]+—[ \t]+(\d{4}-\d{2}-\d{2})[ \t\r]*$`
+	matches := regexp.MustCompile(pattern).FindAllStringSubmatch(string(data), -1)
+	if len(matches) != 1 {
+		return "", fmt.Errorf("CHANGELOG.md must contain exactly one dated '## %s — YYYY-MM-DD' heading; found %d", tag, len(matches))
+	}
+	return matches[0][1], nil
+}

--- a/internal/releasetruth/promotion_test.go
+++ b/internal/releasetruth/promotion_test.go
@@ -1,6 +1,11 @@
 package releasetruth
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestPromotionCheck_RequiresTagTargetCommit(t *testing.T) {
 	m := validManifest()
@@ -76,5 +81,21 @@ func TestValidate_PublishedReleaseClaimsFailClosed(t *testing.T) {
 				t.Fatalf("Validate() = %v, want %s", ps, tt.field)
 			}
 		})
+	}
+}
+
+func setChangelogDate(t *testing.T, root, oldDate, newDate string) {
+	t.Helper()
+	path := filepath.Join(root, "CHANGELOG.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(data), oldDate, newDate, 1)
+	if updated == string(data) {
+		t.Fatalf("CHANGELOG.md has no date %s", oldDate)
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/releasetruth/promotion_test.go
+++ b/internal/releasetruth/promotion_test.go
@@ -1,0 +1,80 @@
+package releasetruth
+
+import "testing"
+
+func TestPromotionCheck_RequiresTagTargetCommit(t *testing.T) {
+	m := validManifest()
+	root := writeReleaseTree(t, "2.15.0-dev.0", m.Release.Tag)
+	wrong := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	if ps := PromotionCheck(m, root, wrong); !hasField(ps, "release.commit.tagTarget") {
+		t.Fatalf("PromotionCheck(wrong tag target) = %v, want release.commit.tagTarget", ps)
+	}
+}
+
+func TestValidate_ReleaseCommitRequiresFullSHA(t *testing.T) {
+	m := validManifest()
+	m.Release.Commit = "e65a0a8"
+	if ps := Validate(m); !hasField(ps, "release.commit") {
+		t.Fatalf("Validate(abbreviated release commit) = %v, want release.commit", ps)
+	}
+}
+
+func TestPromotionCheck_BindsReleaseDateToChangelog(t *testing.T) {
+	m := validManifest()
+	m.Release.Date = "2026-06-03"
+	root := writeReleaseTree(t, "2.15.0-dev.0", m.Release.Tag)
+
+	if ps := PromotionCheck(m, root, m.Release.Commit); !hasField(ps, "release.date.changelog") {
+		t.Fatalf("PromotionCheck(stale date) = %v, want release.date.changelog", ps)
+	}
+}
+
+func TestPromotionCheck_AcceptsBoundPublishedRelease(t *testing.T) {
+	m := validManifest()
+	root := writeReleaseTree(t, "2.15.0-dev.0", m.Release.Tag)
+
+	if ps := PromotionCheck(m, root, m.Release.Commit); len(ps) != 0 {
+		t.Fatalf("PromotionCheck(bound release) = %v, want none", ps)
+	}
+}
+
+func TestValidate_PublishedReleaseClaimsFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Manifest)
+		field  string
+	}{
+		{
+			name: "current security line missing",
+			mutate: func(m *Manifest) {
+				m.Security.SupportedLines = []string{"2.13.x"}
+			},
+			field: "security.supportedLines.current",
+		},
+		{
+			name: "stable component not published",
+			mutate: func(m *Manifest) {
+				m.Components[0].Publication = "unpublished"
+			},
+			field: "components.published.publication",
+		},
+		{
+			name: "stable evidence embeds stale version",
+			mutate: func(m *Manifest) {
+				m.Components[0].Evidence = "released at tag v2.13.0"
+			},
+			field: "components.published.evidence",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validManifest()
+			tt.mutate(m)
+			if ps := Validate(m); !hasField(ps, tt.field) {
+				t.Fatalf("Validate() = %v, want %s", ps, tt.field)
+			}
+		})
+	}
+}

--- a/internal/releasetruth/release.go
+++ b/internal/releasetruth/release.go
@@ -143,6 +143,7 @@ func ReleaseCheck(m *Manifest, repoRoot, tag string) []Problem {
 		version, expectedTag, field = m.Snapshot.Version, m.Snapshot.Tag, "snapshot"
 	} else if m.Candidate != nil {
 		ps = append(ps, Problem{"snapshot.required", "candidate must be frozen as a snapshot before tag validation"})
+		return ps
 	}
 	if tag != expectedTag {
 		ps = append(ps, Problem{field + ".tag", fmt.Sprintf("tag %q does not equal manifest %s tag %q", tag, field, expectedTag)})

--- a/internal/releasetruth/release.go
+++ b/internal/releasetruth/release.go
@@ -1,6 +1,7 @@
 package releasetruth
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,18 @@ var releaseSourceFiles = []releaseSourceFile{
 	{"sdk/python-guard/pyproject.toml", regexp.MustCompile(`(?m)^version\s*=\s*"([^"]+)"`)},
 }
 
+type sourceVersion struct {
+	source  string
+	version string
+}
+
+type nodePackageLock struct {
+	Version  string `json:"version"`
+	Packages map[string]struct {
+		Version string `json:"version"`
+	} `json:"packages"`
+}
+
 // readSourceVersion returns the declared version in a source metadata file.
 func readSourceVersion(repoRoot string, sf releaseSourceFile) (string, error) {
 	data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(sf.file)))
@@ -34,35 +47,85 @@ func readSourceVersion(repoRoot string, sf releaseSourceFile) (string, error) {
 	return m[1], nil
 }
 
-// CheckSourceMetadata verifies that source packages are either marked as
-// unreleased development or exactly stamped to an explicit future candidate.
+func readSourceVersions(repoRoot string) ([]sourceVersion, []error) {
+	versions := make([]sourceVersion, 0, len(releaseSourceFiles)+2)
+	var errs []error
+	for _, sf := range releaseSourceFiles {
+		version, err := readSourceVersion(repoRoot, sf)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", sf.file, err))
+			continue
+		}
+		versions = append(versions, sourceVersion{sf.file, version})
+	}
+	lockVersions, err := readNodePackageLockVersions(repoRoot)
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		versions = append(versions, lockVersions...)
+	}
+	return versions, errs
+}
+
+func readNodePackageLockVersions(repoRoot string) ([]sourceVersion, error) {
+	const name = "sdk/node/package-lock.json"
+	data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(name)))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+	var lock nodePackageLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("%s: decode: %w", name, err)
+	}
+	root, ok := lock.Packages[""]
+	if strings.TrimSpace(lock.Version) == "" || !ok || strings.TrimSpace(root.Version) == "" {
+		return nil, fmt.Errorf("%s: top-level version and packages[\"\"].version are required", name)
+	}
+	return []sourceVersion{
+		{name + "#version", lock.Version},
+		{name + `#packages[""].version`, root.Version},
+	}, nil
+}
+
+// CheckSourceMetadata verifies that source packages are marked as unreleased
+// development or exactly stamped to an explicit candidate or snapshot.
 // Source must never masquerade as the latest published release.
 func CheckSourceMetadata(m *Manifest, repoRoot string) []Problem {
 	var ps []Problem
-	for _, sf := range releaseSourceFiles {
-		v, err := readSourceVersion(repoRoot, sf)
-		if err != nil {
-			ps = append(ps, Problem{"development.source.read", err.Error()})
-			continue
-		}
-		if v == m.Release.Version {
+	versions, errs := readSourceVersions(repoRoot)
+	for _, err := range errs {
+		ps = append(ps, Problem{"development.source.read", err.Error()})
+	}
+	field, expected := sourceExpectation(m)
+	for _, source := range versions {
+		if source.version == m.Release.Version {
 			ps = append(ps, Problem{"development.source.version",
-				fmt.Sprintf("%s version %q equals published release %q", sf.file, v, m.Release.Version)})
+				fmt.Sprintf("%s declares %q, equal to published release %q", source.source, source.version, m.Release.Version)})
 			continue
 		}
-		if m.Candidate != nil {
-			if v != m.Candidate.Version {
-				ps = append(ps, Problem{"candidate.source.version",
-					fmt.Sprintf("%s version %q != candidate %q", sf.file, v, m.Candidate.Version)})
+		if expected != "" {
+			if source.version != expected {
+				ps = append(ps, Problem{field + ".source.version",
+					fmt.Sprintf("%s declares %q, not %s %q", source.source, source.version, field, expected)})
 			}
 			continue
 		}
-		if !isDevelopmentVersion(v) {
+		if !isDevelopmentVersion(source.version) {
 			ps = append(ps, Problem{"development.source.version",
-				fmt.Sprintf("%s version %q is not a development/prerelease marker", sf.file, v)})
+				fmt.Sprintf("%s declares %q without a development/prerelease marker", source.source, source.version)})
 		}
 	}
 	return ps
+}
+
+func sourceExpectation(m *Manifest) (string, string) {
+	if m.Snapshot != nil {
+		return "snapshot", m.Snapshot.Version
+	}
+	if m.Candidate != nil {
+		return "candidate", m.Candidate.Version
+	}
+	return "development", ""
 }
 
 func isDevelopmentVersion(version string) bool {
@@ -70,27 +133,28 @@ func isDevelopmentVersion(version string) bool {
 }
 
 // ReleaseCheck validates that a release tag is internally consistent with the
-// manifest, the source metadata, and the changelog. It is the fail-closed gate
-// a release-tag workflow runs: a release fails unless an approved release-prep
-// commit already synchronized these. It performs local file I/O only.
+// manifest, the source metadata, and the changelog. A future tag requires a
+// prepared snapshot; the snapshot's containing SHA is approved out of band
+// before tag creation. This function performs local file I/O only.
 func ReleaseCheck(m *Manifest, repoRoot, tag string) []Problem {
-	var ps []Problem
+	ps := Validate(m)
 	version, expectedTag, field := m.Release.Version, m.Release.Tag, "release"
-	if m.Candidate != nil {
-		version, expectedTag, field = m.Candidate.Version, m.Candidate.Tag, "candidate"
+	if m.Snapshot != nil {
+		version, expectedTag, field = m.Snapshot.Version, m.Snapshot.Tag, "snapshot"
+	} else if m.Candidate != nil {
+		ps = append(ps, Problem{"snapshot.required", "candidate must be frozen as a snapshot before tag validation"})
 	}
 	if tag != expectedTag {
 		ps = append(ps, Problem{field + ".tag", fmt.Sprintf("tag %q does not equal manifest %s tag %q", tag, field, expectedTag)})
 	}
-	for _, sf := range releaseSourceFiles {
-		v, err := readSourceVersion(repoRoot, sf)
-		if err != nil {
-			ps = append(ps, Problem{"release.source.read", err.Error()})
-			continue
-		}
-		if v != version {
+	versions, errs := readSourceVersions(repoRoot)
+	for _, err := range errs {
+		ps = append(ps, Problem{"release.source.read", err.Error()})
+	}
+	for _, source := range versions {
+		if source.version != version {
 			ps = append(ps, Problem{field + ".source.version",
-				fmt.Sprintf("%s version %q != %s %q (run release prep to sync source with the tag)", sf.file, v, field, version)})
+				fmt.Sprintf("%s declares %q, not %s %q (run release prep to sync source with the tag)", source.source, source.version, field, version)})
 		}
 	}
 	data, err := os.ReadFile(filepath.Join(repoRoot, "CHANGELOG.md"))

--- a/internal/releasetruth/release.go
+++ b/internal/releasetruth/release.go
@@ -34,14 +34,53 @@ func readSourceVersion(repoRoot string, sf releaseSourceFile) (string, error) {
 	return m[1], nil
 }
 
+// CheckSourceMetadata verifies that source packages are either marked as
+// unreleased development or exactly stamped to an explicit future candidate.
+// Source must never masquerade as the latest published release.
+func CheckSourceMetadata(m *Manifest, repoRoot string) []Problem {
+	var ps []Problem
+	for _, sf := range releaseSourceFiles {
+		v, err := readSourceVersion(repoRoot, sf)
+		if err != nil {
+			ps = append(ps, Problem{"development.source.read", err.Error()})
+			continue
+		}
+		if v == m.Release.Version {
+			ps = append(ps, Problem{"development.source.version",
+				fmt.Sprintf("%s version %q equals published release %q", sf.file, v, m.Release.Version)})
+			continue
+		}
+		if m.Candidate != nil {
+			if v != m.Candidate.Version {
+				ps = append(ps, Problem{"candidate.source.version",
+					fmt.Sprintf("%s version %q != candidate %q", sf.file, v, m.Candidate.Version)})
+			}
+			continue
+		}
+		if !isDevelopmentVersion(v) {
+			ps = append(ps, Problem{"development.source.version",
+				fmt.Sprintf("%s version %q is not a development/prerelease marker", sf.file, v)})
+		}
+	}
+	return ps
+}
+
+func isDevelopmentVersion(version string) bool {
+	return strings.Contains(strings.ToLower(version), "dev") || strings.Contains(version, "-")
+}
+
 // ReleaseCheck validates that a release tag is internally consistent with the
 // manifest, the source metadata, and the changelog. It is the fail-closed gate
 // a release-tag workflow runs: a release fails unless an approved release-prep
 // commit already synchronized these. It performs local file I/O only.
 func ReleaseCheck(m *Manifest, repoRoot, tag string) []Problem {
 	var ps []Problem
-	if tag != m.Release.Tag {
-		ps = append(ps, Problem{"release.tag", fmt.Sprintf("tag %q does not equal manifest release tag %q", tag, m.Release.Tag)})
+	version, expectedTag, field := m.Release.Version, m.Release.Tag, "release"
+	if m.Candidate != nil {
+		version, expectedTag, field = m.Candidate.Version, m.Candidate.Tag, "candidate"
+	}
+	if tag != expectedTag {
+		ps = append(ps, Problem{field + ".tag", fmt.Sprintf("tag %q does not equal manifest %s tag %q", tag, field, expectedTag)})
 	}
 	for _, sf := range releaseSourceFiles {
 		v, err := readSourceVersion(repoRoot, sf)
@@ -49,16 +88,16 @@ func ReleaseCheck(m *Manifest, repoRoot, tag string) []Problem {
 			ps = append(ps, Problem{"release.source.read", err.Error()})
 			continue
 		}
-		if v != m.Release.Version {
-			ps = append(ps, Problem{"release.source.version",
-				fmt.Sprintf("%s version %q != release %q (run release prep to sync source with the tag)", sf.file, v, m.Release.Version)})
+		if v != version {
+			ps = append(ps, Problem{field + ".source.version",
+				fmt.Sprintf("%s version %q != %s %q (run release prep to sync source with the tag)", sf.file, v, field, version)})
 		}
 	}
 	data, err := os.ReadFile(filepath.Join(repoRoot, "CHANGELOG.md"))
 	if err != nil {
 		ps = append(ps, Problem{"release.changelog.read", err.Error()})
-	} else if !strings.Contains(string(data), "## "+m.Release.Tag+" ") && !strings.Contains(string(data), "## "+m.Release.Tag+"\n") {
-		ps = append(ps, Problem{"release.changelog", "CHANGELOG.md has no '## " + m.Release.Tag + "' entry"})
+	} else if !strings.Contains(string(data), "## "+expectedTag+" ") && !strings.Contains(string(data), "## "+expectedTag+"\n") {
+		ps = append(ps, Problem{field + ".changelog", "CHANGELOG.md has no '## " + expectedTag + "' entry"})
 	}
 	return ps
 }

--- a/internal/releasetruth/release_state.go
+++ b/internal/releasetruth/release_state.go
@@ -1,6 +1,11 @@
 package releasetruth
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+var evidenceVersion = regexp.MustCompile(`(?i)\bv?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(x|0|[1-9]\d*)([.-][0-9a-z]+)*\b`)
 
 type futureCoordinate struct {
 	version string
@@ -68,12 +73,23 @@ func semverGreater(candidate, published string) bool {
 	return false
 }
 
-func checkPublishedComponentVersions(m *Manifest) []Problem {
+func checkPublishedComponentClaims(m *Manifest) []Problem {
 	var ps []Problem
 	for _, c := range m.Components {
-		if c.Tier == "stable" && c.Version != m.Release.Version {
+		if c.Tier != "stable" {
+			continue
+		}
+		if c.Version != m.Release.Version {
 			ps = append(ps, Problem{"components.published.version",
 				"stable component " + c.Name + " must remain at published release " + m.Release.Version})
+		}
+		if c.Publication != "published" {
+			ps = append(ps, Problem{"components.published.publication",
+				"stable component " + c.Name + " must be marked published"})
+		}
+		if evidenceVersion.MatchString(c.Evidence) {
+			ps = append(ps, Problem{"components.published.evidence",
+				"stable component " + c.Name + " evidence must be version-neutral; version binding belongs in components[].version"})
 		}
 	}
 	return ps

--- a/internal/releasetruth/release_state.go
+++ b/internal/releasetruth/release_state.go
@@ -1,0 +1,80 @@
+package releasetruth
+
+import "strings"
+
+type futureCoordinate struct {
+	version string
+	tag     string
+	channel string
+}
+
+func checkReleaseState(m *Manifest) []Problem {
+	var ps []Problem
+	if m.Candidate != nil && m.Snapshot != nil {
+		ps = append(ps, Problem{"releaseState", "candidate and snapshot are mutually exclusive"})
+	}
+	if m.Candidate != nil && m.SchemaVersion == "1.0.0" {
+		ps = append(ps, Problem{"candidate.schemaVersion", "candidate requires schemaVersion >= 1.1.0"})
+	}
+	if m.Snapshot != nil && m.SchemaVersion != "1.2.0" {
+		ps = append(ps, Problem{"snapshot.schemaVersion", "snapshot requires schemaVersion 1.2.0"})
+	}
+	return ps
+}
+
+func checkCandidate(m *Manifest) []Problem {
+	if m.Candidate == nil {
+		return nil
+	}
+	c := m.Candidate
+	return checkFutureCoordinate("candidate", futureCoordinate{c.Version, c.Tag, c.Channel}, m.Release.Version)
+}
+
+func checkSnapshot(m *Manifest) []Problem {
+	if m.Snapshot == nil {
+		return nil
+	}
+	s := m.Snapshot
+	return checkFutureCoordinate("snapshot", futureCoordinate{s.Version, s.Tag, s.Channel}, m.Release.Version)
+}
+
+func checkFutureCoordinate(field string, c futureCoordinate, published string) []Problem {
+	var ps []Problem
+	if !reSemver.MatchString(c.version) {
+		ps = append(ps, Problem{field + ".version", "must be canonical MAJOR.MINOR.PATCH: " + c.version})
+	} else if reSemver.MatchString(published) && !semverGreater(c.version, published) {
+		ps = append(ps, Problem{field + ".version", "must be newer than published release " + published})
+	}
+	if c.tag != "v"+c.version {
+		ps = append(ps, Problem{field + ".tag", "tag must equal v" + c.version + ", got " + c.tag})
+	}
+	if c.channel != "stable" {
+		ps = append(ps, Problem{field + ".channel", "stable version/tag require channel stable, got " + c.channel})
+	}
+	return ps
+}
+
+func semverGreater(candidate, published string) bool {
+	candidateParts := strings.Split(candidate, ".")
+	publishedParts := strings.Split(published, ".")
+	for i := 0; i < 3; i++ {
+		if len(candidateParts[i]) != len(publishedParts[i]) {
+			return len(candidateParts[i]) > len(publishedParts[i])
+		}
+		if candidateParts[i] != publishedParts[i] {
+			return candidateParts[i] > publishedParts[i]
+		}
+	}
+	return false
+}
+
+func checkPublishedComponentVersions(m *Manifest) []Problem {
+	var ps []Problem
+	for _, c := range m.Components {
+		if c.Tier == "stable" && c.Version != m.Release.Version {
+			ps = append(ps, Problem{"components.published.version",
+				"stable component " + c.Name + " must remain at published release " + m.Release.Version})
+		}
+	}
+	return ps
+}

--- a/internal/releasetruth/release_state_test.go
+++ b/internal/releasetruth/release_state_test.go
@@ -1,0 +1,202 @@
+package releasetruth
+
+import (
+	"strings"
+	"testing"
+)
+
+func validSnapshotManifest() *Manifest {
+	m := validManifest()
+	m.Snapshot = &Snapshot{
+		Version: "2.15.0",
+		Tag:     "v2.15.0",
+		Channel: "stable",
+	}
+	return m
+}
+
+func TestValidate_ReleaseStateSchemaCoupling(t *testing.T) {
+	tests := []struct {
+		name   string
+		build  func() *Manifest
+		schema string
+		field  string
+	}{
+		{"candidate needs schema 1.1 or newer", validCandidateManifest, "1.0.0", "candidate.schemaVersion"},
+		{"snapshot needs schema 1.2 or newer", validSnapshotManifest, "1.1.0", "snapshot.schemaVersion"},
+		{"unknown schema rejected", validSnapshotManifest, "9.0.0", "schemaVersion"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.build()
+			m.SchemaVersion = tt.schema
+			if ps := Validate(m); !hasField(ps, tt.field) {
+				t.Fatalf("Validate(schema %s) = %v, want %s", tt.schema, ps, tt.field)
+			}
+		})
+	}
+}
+
+func TestValidate_CandidateRemainsCompatibleWithSchemaOneOne(t *testing.T) {
+	m := validCandidateManifest()
+	m.SchemaVersion = "1.1.0"
+	if ps := Validate(m); hasField(ps, "candidate.schemaVersion") || hasField(ps, "schemaVersion") {
+		t.Fatalf("Validate(schema 1.1 candidate) = %v, want schema compatibility", ps)
+	}
+}
+
+func TestValidate_ReleaseStatesAreMutuallyExclusive(t *testing.T) {
+	m := validSnapshotManifest()
+	m.Candidate = validCandidateManifest().Candidate
+	if ps := Validate(m); !hasField(ps, "releaseState") {
+		t.Fatalf("Validate(candidate+snapshot) = %v, want releaseState", ps)
+	}
+}
+
+func TestValidate_RejectsNonCanonicalReleaseCoordinates(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() *Manifest
+		field string
+	}{
+		{"candidate leading zero", func() *Manifest {
+			m := validCandidateManifest()
+			m.Candidate.Version, m.Candidate.Tag = "02.15.0", "v02.15.0"
+			return m
+		}, "candidate.version"},
+		{"snapshot leading zero", func() *Manifest {
+			m := validSnapshotManifest()
+			m.Snapshot.Version, m.Snapshot.Tag = "02.15.0", "v02.15.0"
+			return m
+		}, "snapshot.version"},
+		{"candidate beta channel on stable tag", func() *Manifest {
+			m := validCandidateManifest()
+			m.Candidate.Channel = "beta"
+			return m
+		}, "candidate.channel"},
+		{"snapshot rc channel on stable tag", func() *Manifest {
+			m := validSnapshotManifest()
+			m.Snapshot.Channel = "rc"
+			return m
+		}, "snapshot.channel"},
+		{"release leading zero", func() *Manifest {
+			m := validManifest()
+			m.Release.Version, m.Release.Tag = "02.14.0", "v02.14.0"
+			return m
+		}, "release.version"},
+		{"release beta channel on stable tag", func() *Manifest {
+			m := validManifest()
+			m.Release.Channel = "beta"
+			return m
+		}, "release.channel"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if ps := Validate(tt.build()); !hasField(ps, tt.field) {
+				t.Fatalf("Validate() = %v, want %s", ps, tt.field)
+			}
+		})
+	}
+}
+
+func TestValidate_PromotionRequiresPublishedComponentVersions(t *testing.T) {
+	m := validManifest()
+	m.Release.Version, m.Release.Tag = "2.15.0", "v2.15.0"
+	if ps := Validate(m); !hasField(ps, "components.published.version") {
+		t.Fatalf("Validate(unreconciled promotion) = %v, want components.published.version", ps)
+	}
+}
+
+func TestValidate_PreReleaseStateCannotAdvertiseCandidateComponents(t *testing.T) {
+	for _, build := range []func() *Manifest{validCandidateManifest, validSnapshotManifest} {
+		m := build()
+		for i := range m.Components {
+			if m.Components[i].Tier == "stable" {
+				m.Components[i].Version = "2.15.0"
+				break
+			}
+		}
+		if ps := Validate(m); !hasField(ps, "components.published.version") {
+			t.Fatalf("Validate(pre-bumped component) = %v, want components.published.version", ps)
+		}
+	}
+}
+
+func TestCheckSourceMetadata_GatesBothPackageLockVersions(t *testing.T) {
+	for _, tt := range []struct {
+		name, top, root string
+	}{
+		{"top-level lock version", "2.15.0-dev.0", "2.15.0"},
+		{"root package lock version", "2.15.0", "2.15.0-dev.0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validCandidateManifest()
+			root := writeReleaseTree(t, "2.15.0", "v2.15.0")
+			writeNodePackageLock(t, root, tt.top, tt.root)
+			if ps := CheckSourceMetadata(m, root); !hasField(ps, "candidate.source.version") {
+				t.Fatalf("CheckSourceMetadata(stale lock) = %v, want candidate.source.version", ps)
+			}
+		})
+	}
+}
+
+func TestCheckSourceMetadata_RejectsIncompletePackageLock(t *testing.T) {
+	m := validCandidateManifest()
+	root := writeReleaseTree(t, "2.15.0", "v2.15.0")
+	writeNodePackageLock(t, root, "2.15.0", "")
+	if ps := CheckSourceMetadata(m, root); !hasField(ps, "development.source.read") {
+		t.Fatalf("CheckSourceMetadata(incomplete lock) = %v, want development.source.read", ps)
+	}
+}
+
+func TestReleaseCheck_RequiresSnapshotInsteadOfCandidate(t *testing.T) {
+	m := validCandidateManifest()
+	root := writeReleaseTree(t, "2.15.0", "v2.15.0")
+	if ps := ReleaseCheck(m, root, "v2.15.0"); !hasField(ps, "snapshot.required") {
+		t.Fatalf("ReleaseCheck(candidate) = %v, want snapshot.required", ps)
+	}
+}
+
+func TestReleaseSnapshot_IsTaggableWithoutClaimingPublication(t *testing.T) {
+	m := validSnapshotManifest()
+	root := writeReleaseTree(t, "2.15.0", "v2.15.0")
+	if ps := Validate(m); len(ps) != 0 {
+		t.Fatalf("Validate(snapshot) = %v", ps)
+	}
+	if ps := CheckSourceMetadata(m, root); len(ps) != 0 {
+		t.Fatalf("CheckSourceMetadata(snapshot) = %v", ps)
+	}
+	if ps := ReleaseCheck(m, root, "v2.15.0"); len(ps) != 0 {
+		t.Fatalf("ReleaseCheck(snapshot) = %v", ps)
+	}
+	for _, id := range []string{"release-status", "version-policy"} {
+		got, err := RenderBlock(m, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(got, "Prepared release snapshot") || !strings.Contains(got, "publication status is not asserted") {
+			t.Fatalf("RenderBlock(%s) = %q, want neutral snapshot status", id, got)
+		}
+		if strings.Contains(got, "snapshot (not published)") {
+			t.Fatalf("RenderBlock(%s) falsely claims snapshot is unpublished: %q", id, got)
+		}
+	}
+}
+
+func TestPostPublicationPromotion_RestoresDevelopmentState(t *testing.T) {
+	m := validSnapshotManifest()
+	m.Release.Version, m.Release.Tag = "2.15.0", "v2.15.0"
+	m.Snapshot = nil
+	for i := range m.Components {
+		if m.Components[i].Tier == "stable" {
+			m.Components[i].Version = m.Release.Version
+		}
+	}
+	root := writeReleaseTree(t, "2.16.0-dev.0", "v2.15.0")
+	if ps := Validate(m); len(ps) != 0 {
+		t.Fatalf("Validate(promoted release) = %v", ps)
+	}
+	if ps := CheckSourceMetadata(m, root); len(ps) != 0 {
+		t.Fatalf("CheckSourceMetadata(next development) = %v", ps)
+	}
+}

--- a/internal/releasetruth/release_state_test.go
+++ b/internal/releasetruth/release_state_test.go
@@ -186,6 +186,8 @@ func TestReleaseSnapshot_IsTaggableWithoutClaimingPublication(t *testing.T) {
 func TestPostPublicationPromotion_RestoresDevelopmentState(t *testing.T) {
 	m := validSnapshotManifest()
 	m.Release.Version, m.Release.Tag = "2.15.0", "v2.15.0"
+	m.Release.Date = "2026-07-20"
+	m.Release.Commit = strings.Repeat("b", 40)
 	m.Snapshot = nil
 	m.Security.SupportedLines = []string{"2.15.x"}
 	for i := range m.Components {
@@ -194,6 +196,7 @@ func TestPostPublicationPromotion_RestoresDevelopmentState(t *testing.T) {
 		}
 	}
 	root := writeReleaseTree(t, "2.16.0-dev.0", "v2.15.0")
+	setChangelogDate(t, root, "2026-06-02", m.Release.Date)
 	if ps := Validate(m); len(ps) != 0 {
 		t.Fatalf("Validate(promoted release) = %v", ps)
 	}

--- a/internal/releasetruth/release_state_test.go
+++ b/internal/releasetruth/release_state_test.go
@@ -187,6 +187,7 @@ func TestPostPublicationPromotion_RestoresDevelopmentState(t *testing.T) {
 	m := validSnapshotManifest()
 	m.Release.Version, m.Release.Tag = "2.15.0", "v2.15.0"
 	m.Snapshot = nil
+	m.Security.SupportedLines = []string{"2.15.x"}
 	for i := range m.Components {
 		if m.Components[i].Tier == "stable" {
 			m.Components[i].Version = m.Release.Version
@@ -198,5 +199,8 @@ func TestPostPublicationPromotion_RestoresDevelopmentState(t *testing.T) {
 	}
 	if ps := CheckSourceMetadata(m, root); len(ps) != 0 {
 		t.Fatalf("CheckSourceMetadata(next development) = %v", ps)
+	}
+	if ps := PromotionCheck(m, root, m.Release.Commit); len(ps) != 0 {
+		t.Fatalf("PromotionCheck(promoted release) = %v", ps)
 	}
 }

--- a/internal/releasetruth/release_test.go
+++ b/internal/releasetruth/release_test.go
@@ -1,6 +1,7 @@
 package releasetruth
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,10 +22,37 @@ func writeReleaseTree(t *testing.T, version, tag string) string {
 		}
 	}
 	mk("sdk/node/package.json", `{"name":"cap-sdk-node","version":"`+version+`"}`)
+	writeNodePackageLock(t, root, version, version)
 	mk("sdk/python/pyproject.toml", "[project]\nname = \"cap-sdk-python\"\nversion = \""+version+"\"\n")
 	mk("sdk/python-guard/pyproject.toml", "[project]\nname = \"cordum-guard\"\nversion = \""+version+"\"\n")
 	mk("CHANGELOG.md", "# Changelog\n\n## "+tag+" — 2026-06-02\n\n- release\n")
 	return root
+}
+
+func writeNodePackageLock(t *testing.T, root, topLevelVersion, rootPackageVersion string) {
+	t.Helper()
+	type packageEntry struct {
+		Version string `json:"version"`
+	}
+	lock := struct {
+		Name     string                  `json:"name"`
+		Version  string                  `json:"version"`
+		Packages map[string]packageEntry `json:"packages"`
+	}{
+		Name:    "cap-sdk-node",
+		Version: topLevelVersion,
+		Packages: map[string]packageEntry{
+			"": {Version: rootPackageVersion},
+		},
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "sdk", "node", "package-lock.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func releaseManifest(version, tag string) *Manifest {

--- a/internal/releasetruth/validate.go
+++ b/internal/releasetruth/validate.go
@@ -25,6 +25,7 @@ func Validate(m *Manifest) []Problem {
 	var ps []Problem
 	ps = append(ps, checkSchema(m)...)
 	ps = append(ps, checkRelease(m)...)
+	ps = append(ps, checkCandidate(m)...)
 	ps = append(ps, checkDevelopment(m)...)
 	ps = append(ps, checkWire(m)...)
 	ps = append(ps, checkSpecs(m)...)
@@ -62,6 +63,48 @@ func checkRelease(m *Manifest) []Problem {
 		ps = append(ps, Problem{"release.channel", "unknown channel: " + r.Channel})
 	}
 	return ps
+}
+
+func checkCandidate(m *Manifest) []Problem {
+	if m.Candidate == nil {
+		return nil
+	}
+	c := *m.Candidate
+	var ps []Problem
+	if !reSemver.MatchString(c.Version) {
+		ps = append(ps, Problem{"candidate.version", "must be MAJOR.MINOR.PATCH: " + c.Version})
+	} else if reSemver.MatchString(m.Release.Version) && !semverGreater(c.Version, m.Release.Version) {
+		ps = append(ps, Problem{"candidate.version", "must be newer than published release " + m.Release.Version})
+	}
+	if c.Tag != "v"+c.Version {
+		ps = append(ps, Problem{"candidate.tag", "tag must equal v" + c.Version + ", got " + c.Tag})
+	}
+	if !validChannels[c.Channel] {
+		ps = append(ps, Problem{"candidate.channel", "unknown channel: " + c.Channel})
+	}
+	return ps
+}
+
+func semverGreater(candidate, published string) bool {
+	candidateParts := strings.Split(candidate, ".")
+	publishedParts := strings.Split(published, ".")
+	for i := 0; i < 3; i++ {
+		candidatePart := strings.TrimLeft(candidateParts[i], "0")
+		publishedPart := strings.TrimLeft(publishedParts[i], "0")
+		if candidatePart == "" {
+			candidatePart = "0"
+		}
+		if publishedPart == "" {
+			publishedPart = "0"
+		}
+		if len(candidatePart) != len(publishedPart) {
+			return len(candidatePart) > len(publishedPart)
+		}
+		if candidatePart != publishedPart {
+			return candidatePart > publishedPart
+		}
+	}
+	return false
 }
 
 func checkDevelopment(m *Manifest) []Problem {

--- a/internal/releasetruth/validate.go
+++ b/internal/releasetruth/validate.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	reSemver = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
-	reDate   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
-	reHexSHA = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+	reSemver  = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
+	reDate    = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	reHexSHA  = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+	reFullSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
 )
 
 var (
@@ -31,7 +32,7 @@ func Validate(m *Manifest) []Problem {
 	ps = append(ps, checkWire(m)...)
 	ps = append(ps, checkSpecs(m)...)
 	ps = append(ps, checkComponents(m)...)
-	ps = append(ps, checkPublishedComponentVersions(m)...)
+	ps = append(ps, checkPublishedComponentClaims(m)...)
 	ps = append(ps, checkTransports(m)...)
 	ps = append(ps, checkToolchains(m)...)
 	ps = append(ps, checkSecurity(m)...)
@@ -60,8 +61,8 @@ func checkRelease(m *Manifest) []Problem {
 	if !reDate.MatchString(r.Date) {
 		ps = append(ps, Problem{"release.date", "must be YYYY-MM-DD: " + r.Date})
 	}
-	if !reHexSHA.MatchString(r.Commit) {
-		ps = append(ps, Problem{"release.commit", "must be a 7-40 char hex sha: " + r.Commit})
+	if !reFullSHA.MatchString(r.Commit) {
+		ps = append(ps, Problem{"release.commit", "must be the full 40-char tag target sha: " + r.Commit})
 	}
 	if r.Channel != "stable" {
 		ps = append(ps, Problem{"release.channel", "stable version/tag require channel stable, got " + r.Channel})
@@ -214,10 +215,30 @@ func checkSecurity(m *Manifest) []Problem {
 	if len(m.Security.SupportedLines) == 0 {
 		ps = append(ps, Problem{"security.supportedLines", "at least one supported release line is required"})
 	}
+	if current, ok := currentReleaseLine(m.Release.Version); ok && !contains(m.Security.SupportedLines, current) {
+		ps = append(ps, Problem{"security.supportedLines.current", "supported lines must include current release line " + current})
+	}
 	if strings.TrimSpace(m.Security.ReportingRoute) == "" {
 		ps = append(ps, Problem{"security.reportingRoute", "a vulnerability reporting route is required"})
 	}
 	return ps
+}
+
+func currentReleaseLine(version string) (string, bool) {
+	if !reSemver.MatchString(version) {
+		return "", false
+	}
+	parts := strings.Split(version, ".")
+	return parts[0] + "." + parts[1] + ".x", true
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func checkLinks(m *Manifest) []Problem {

--- a/internal/releasetruth/validate.go
+++ b/internal/releasetruth/validate.go
@@ -6,13 +6,12 @@ import (
 )
 
 var (
-	reSemver = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	reSemver = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
 	reDate   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 	reHexSHA = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
 )
 
 var (
-	validChannels  = map[string]bool{"stable": true, "beta": true, "rc": true}
 	validKinds     = map[string]bool{"sdk": true, "extension": true}
 	validTiers     = map[string]bool{"stable": true, "experimental": true, "community": true}
 	validTransport = map[string]bool{"supported": true, "experimental": true}
@@ -24,12 +23,15 @@ var (
 func Validate(m *Manifest) []Problem {
 	var ps []Problem
 	ps = append(ps, checkSchema(m)...)
+	ps = append(ps, checkReleaseState(m)...)
 	ps = append(ps, checkRelease(m)...)
 	ps = append(ps, checkCandidate(m)...)
+	ps = append(ps, checkSnapshot(m)...)
 	ps = append(ps, checkDevelopment(m)...)
 	ps = append(ps, checkWire(m)...)
 	ps = append(ps, checkSpecs(m)...)
 	ps = append(ps, checkComponents(m)...)
+	ps = append(ps, checkPublishedComponentVersions(m)...)
 	ps = append(ps, checkTransports(m)...)
 	ps = append(ps, checkToolchains(m)...)
 	ps = append(ps, checkSecurity(m)...)
@@ -38,10 +40,12 @@ func Validate(m *Manifest) []Problem {
 }
 
 func checkSchema(m *Manifest) []Problem {
-	if !reSemver.MatchString(m.SchemaVersion) {
-		return []Problem{{"schemaVersion", "must be MAJOR.MINOR.PATCH: " + m.SchemaVersion}}
+	switch m.SchemaVersion {
+	case "1.0.0", "1.1.0", "1.2.0":
+		return nil
+	default:
+		return []Problem{{"schemaVersion", "unsupported manifest schema: " + m.SchemaVersion}}
 	}
-	return nil
 }
 
 func checkRelease(m *Manifest) []Problem {
@@ -59,52 +63,10 @@ func checkRelease(m *Manifest) []Problem {
 	if !reHexSHA.MatchString(r.Commit) {
 		ps = append(ps, Problem{"release.commit", "must be a 7-40 char hex sha: " + r.Commit})
 	}
-	if !validChannels[r.Channel] {
-		ps = append(ps, Problem{"release.channel", "unknown channel: " + r.Channel})
+	if r.Channel != "stable" {
+		ps = append(ps, Problem{"release.channel", "stable version/tag require channel stable, got " + r.Channel})
 	}
 	return ps
-}
-
-func checkCandidate(m *Manifest) []Problem {
-	if m.Candidate == nil {
-		return nil
-	}
-	c := *m.Candidate
-	var ps []Problem
-	if !reSemver.MatchString(c.Version) {
-		ps = append(ps, Problem{"candidate.version", "must be MAJOR.MINOR.PATCH: " + c.Version})
-	} else if reSemver.MatchString(m.Release.Version) && !semverGreater(c.Version, m.Release.Version) {
-		ps = append(ps, Problem{"candidate.version", "must be newer than published release " + m.Release.Version})
-	}
-	if c.Tag != "v"+c.Version {
-		ps = append(ps, Problem{"candidate.tag", "tag must equal v" + c.Version + ", got " + c.Tag})
-	}
-	if !validChannels[c.Channel] {
-		ps = append(ps, Problem{"candidate.channel", "unknown channel: " + c.Channel})
-	}
-	return ps
-}
-
-func semverGreater(candidate, published string) bool {
-	candidateParts := strings.Split(candidate, ".")
-	publishedParts := strings.Split(published, ".")
-	for i := 0; i < 3; i++ {
-		candidatePart := strings.TrimLeft(candidateParts[i], "0")
-		publishedPart := strings.TrimLeft(publishedParts[i], "0")
-		if candidatePart == "" {
-			candidatePart = "0"
-		}
-		if publishedPart == "" {
-			publishedPart = "0"
-		}
-		if len(candidatePart) != len(publishedPart) {
-			return len(candidatePart) > len(publishedPart)
-		}
-		if candidatePart != publishedPart {
-			return candidatePart > publishedPart
-		}
-	}
-	return false
 }
 
 func checkDevelopment(m *Manifest) []Problem {

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./manifest.schema.json",
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "release": {
     "version": "2.14.0",
     "tag": "v2.14.0",

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -53,7 +53,7 @@
       "version": "2.14.0",
       "toolchain": "go1.25.12",
       "publication": "published",
-      "evidence": "sdk/go conformance_test.go + CI NATS e2e; released at tag v2.14.0"
+      "evidence": "sdk/go conformance_test.go plus CI real-NATS end-to-end and immutable-tag publication verification"
     },
     {
       "name": "cap-node",
@@ -66,7 +66,7 @@
       "version": "2.14.0",
       "toolchain": "node20",
       "publication": "published",
-      "evidence": "CI build+test; released at tag v2.14.0"
+      "evidence": "CI build, source tests, package verification, and immutable-tag npm publication verification"
     },
     {
       "name": "cap-python",
@@ -79,7 +79,7 @@
       "version": "2.14.0",
       "toolchain": "python3.11",
       "publication": "published",
-      "evidence": "CI pytest; released at tag v2.14.0"
+      "evidence": "CI pytest, clean wheel and sdist verification, and immutable-tag PyPI publication verification"
     },
     {
       "name": "cordum-guard",
@@ -92,7 +92,7 @@
       "version": "2.14.0",
       "toolchain": "python3.11",
       "publication": "published",
-      "evidence": "unit tests; published on PyPI on the release train (latest 2.14.0). Source pyproject carries an in-development 2.15.0.dev0 prerelease that must not be treated as the published artifact."
+      "evidence": "unit tests plus immutable-tag PyPI publication verification for the manifest-declared release"
     },
     { "name": "cap-cpp", "kind": "sdk", "tier": "experimental", "language": "cpp", "package": "", "registry": "", "import": "", "version": "", "toolchain": "", "publication": "source-only", "evidence": "" },
     { "name": "cap-dotnet", "kind": "sdk", "tier": "experimental", "language": "dotnet", "package": "", "registry": "", "import": "", "version": "", "toolchain": "", "publication": "source-only", "evidence": "" },

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./manifest.schema.json",
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "release": {
     "version": "2.14.0",
     "tag": "v2.14.0",

--- a/release/manifest.schema.json
+++ b/release/manifest.schema.json
@@ -2,35 +2,57 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/cordum-io/cap/release/manifest.schema.json",
   "title": "CAP Release Manifest",
-  "description": "The single canonical, hand-edited source of current CAP release, future candidate, wire, SDK, transport, toolchain, and security-support truth. Documentation and CI derive from this file; changed source must never relabel the latest published release. Structural validation lives here; semantic validation (tag==v+version, evidence gates, safe paths, uniqueness) is enforced by cmd/cap-release check.",
+  "description": "The single canonical, hand-edited source of the latest verified published CAP release, future candidate or prepared release snapshot, wire, SDK, transport, toolchain, and security-support truth. Documentation and CI derive from this file; changed source must never relabel the latest verified published release. Structural validation lives here; semantic validation (tag==v+version, evidence gates, safe paths, uniqueness) is enforced by cmd/cap-release check.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schemaVersion", "release", "development", "wire", "specs", "components", "transports", "toolchains", "security", "links"],
+  "allOf": [
+    { "not": { "required": ["candidate", "snapshot"] } },
+    {
+      "if": { "required": ["candidate"] },
+      "then": { "properties": { "schemaVersion": { "enum": ["1.1.0", "1.2.0"] } } }
+    },
+    {
+      "if": { "required": ["snapshot"] },
+      "then": { "properties": { "schemaVersion": { "const": "1.2.0" } } }
+    }
+  ],
   "properties": {
     "$schema": { "type": "string", "description": "Optional pointer to this schema for editor tooling." },
-    "schemaVersion": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$", "description": "Version of the manifest format itself." },
+    "schemaVersion": { "type": "string", "enum": ["1.0.0", "1.1.0", "1.2.0"], "description": "Supported version of the manifest format itself." },
     "release": {
       "type": "object",
       "additionalProperties": false,
       "required": ["version", "tag", "date", "commit", "channel"],
-      "description": "The latest published artifact line. Distinct from development.",
+      "description": "The latest independently verified, fully published artifact line. Distinct from development and prepared snapshot state.",
       "properties": {
-        "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$", "description": "SemVer of the released artifacts (no leading v)." },
-        "tag": { "type": "string", "pattern": "^v\\d+\\.\\d+\\.\\d+$", "description": "Git tag; must equal 'v'+version." },
+        "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Canonical stable SemVer of the released artifacts (no leading v or leading zero identifiers)." },
+        "tag": { "type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Stable Git tag; must equal 'v'+version." },
         "date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "commit": { "type": "string", "pattern": "^[0-9a-f]{7,40}$", "description": "Tag target commit SHA." },
-        "channel": { "type": "string", "enum": ["stable", "beta", "rc"] }
+        "channel": { "type": "string", "const": "stable" }
       }
     },
     "candidate": {
       "type": "object",
       "additionalProperties": false,
       "required": ["version", "tag", "channel"],
-      "description": "Source prepared for a future release. This is not the latest published artifact; the tag workflow binds its immutable target SHA after merge.",
+      "description": "Mutable source prepared for a future release. This is not the latest published artifact and cannot pass the tag gate; freeze it as a snapshot first.",
       "properties": {
-        "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$", "description": "Stable SemVer prepared in source metadata (no leading v)." },
-        "tag": { "type": "string", "pattern": "^v\\d+\\.\\d+\\.\\d+$", "description": "Future Git tag; must equal 'v'+version." },
-        "channel": { "type": "string", "enum": ["stable", "beta", "rc"] }
+        "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Canonical stable SemVer prepared in source metadata (no leading v or leading zero identifiers)." },
+        "tag": { "type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Future stable Git tag; must equal 'v'+version." },
+        "channel": { "type": "string", "const": "stable" }
+      }
+    },
+    "snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "tag", "channel"],
+      "description": "Source frozen for exact tag and containing-commit-SHA approval. Presence makes no claim that the tag or registry artifacts exist; promotion to release happens only after publication is independently verified.",
+      "properties": {
+        "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Canonical stable SemVer frozen in source metadata." },
+        "tag": { "type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Approved future stable Git tag; must equal 'v'+version." },
+        "channel": { "type": "string", "const": "stable" }
       }
     },
     "development": {

--- a/release/manifest.schema.json
+++ b/release/manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/cordum-io/cap/release/manifest.schema.json",
   "title": "CAP Release Manifest",
-  "description": "The single canonical, hand-edited source of current CAP release, wire, SDK, transport, toolchain, and security-support truth. Documentation and CI derive from this file; it must never be relabelled from changed source. Structural validation lives here; semantic validation (tag==v+version, evidence gates, safe paths, uniqueness) is enforced by cmd/cap-release check.",
+  "description": "The single canonical, hand-edited source of current CAP release, future candidate, wire, SDK, transport, toolchain, and security-support truth. Documentation and CI derive from this file; changed source must never relabel the latest published release. Structural validation lives here; semantic validation (tag==v+version, evidence gates, safe paths, uniqueness) is enforced by cmd/cap-release check.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schemaVersion", "release", "development", "wire", "specs", "components", "transports", "toolchains", "security", "links"],
@@ -19,6 +19,17 @@
         "tag": { "type": "string", "pattern": "^v\\d+\\.\\d+\\.\\d+$", "description": "Git tag; must equal 'v'+version." },
         "date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "commit": { "type": "string", "pattern": "^[0-9a-f]{7,40}$", "description": "Tag target commit SHA." },
+        "channel": { "type": "string", "enum": ["stable", "beta", "rc"] }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "tag", "channel"],
+      "description": "Source prepared for a future release. This is not the latest published artifact; the tag workflow binds its immutable target SHA after merge.",
+      "properties": {
+        "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$", "description": "Stable SemVer prepared in source metadata (no leading v)." },
+        "tag": { "type": "string", "pattern": "^v\\d+\\.\\d+\\.\\d+$", "description": "Future Git tag; must equal 'v'+version." },
         "channel": { "type": "string", "enum": ["stable", "beta", "rc"] }
       }
     },

--- a/release/manifest.schema.json
+++ b/release/manifest.schema.json
@@ -29,7 +29,7 @@
         "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Canonical stable SemVer of the released artifacts (no leading v or leading zero identifiers)." },
         "tag": { "type": "string", "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "description": "Stable Git tag; must equal 'v'+version." },
         "date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "commit": { "type": "string", "pattern": "^[0-9a-f]{7,40}$", "description": "Tag target commit SHA." },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$", "description": "Full tag target commit SHA; promotion-check resolves and compares the tag locally." },
         "channel": { "type": "string", "const": "stable" }
       }
     },
@@ -112,7 +112,7 @@
           "version": { "type": "string" },
           "toolchain": { "type": "string" },
           "publication": { "type": "string", "enum": ["published", "unpublished", "source-only"] },
-          "evidence": { "type": "string", "description": "Behavioral evidence; required non-empty for stable tier." }
+          "evidence": { "type": "string", "description": "Version-neutral behavioral and publication evidence; required non-empty for stable tier. Release binding belongs in version." }
         }
       }
     },

--- a/spec/00-index.md
+++ b/spec/00-index.md
@@ -18,7 +18,7 @@ Tags: `conformance`, `fixtures`, `testing`, `signing`, `deterministic`.
 - Repository/SDK releases track implementation and are pinned by tag for reproducibility.
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current verified published release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -17,7 +17,7 @@ This wiki provides a comprehensive guide to understanding, using, and contributi
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
+- **Current verified published release:** 2.14.0 (tag `v2.14.0`, 2026-06-02, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents


### PR DESCRIPTION
## Summary
- model mutable release candidates separately from immutable, publication-neutral tag snapshots
- enforce schema/state coupling, strict stable coordinates, lockfile parity, and published-component claim integrity
- keep exact tag/SHA approval and later publication as separate human gates

## Safety
- no candidate or snapshot value is set
- no tag or release is created
- no registry publication workflow is triggered

## Verification
- `go test -p 1 -count=1 ./...`
- `go vet ./internal/releasetruth ./cmd/cap-release`
- `go test -count=3 ./internal/releasetruth`
- `go run ./cmd/cap-release check`
- `go run ./cmd/cap-release render --check`
- release links/schema/adversarial lifecycle fixtures

Independent adversarial review is in progress; draft remains non-mergeable until that review is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `promotion-check` to verify release tags, commit targets, and changelog dates before publication.
  * Added support for release candidates and immutable snapshots with clearer publication status.
  * Expanded validation to cover source versions, package metadata, schema rules, and release evidence.

* **Bug Fixes**
  * Release checks now fail closed for invalid tags, incomplete metadata, unsupported versions, and mismatched release details.

* **Documentation**
  * Updated release status wording to “Current verified published release” across documentation and project pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->