### PR TITLE
fix(sdk): sign managed production results

### DIFF
--- a/sdk/node/src/runtime.ts
+++ b/sdk/node/src/runtime.ts
@@ -19,6 +19,12 @@ import { encodeOutboundPacket, prepareOutboundPacket } from "./packet-boundary";
 import { DecodedProductionPacket, extractProductionSignature, verifyProductionPacket, ProductionTrustStore, ProductionWireError } from "./production-signing";
 import { ReplayStore, ReplayOutcome, ReplayConflictError, ReplayStoreUnavailableError } from "./production-replay";
 import { validateIdentityBinding, IdentityMismatchError } from "./production-validation";
+import {
+  bindProductionEvent,
+  freezeProductionAuthority,
+  sealProductionEvent,
+  type ProductionEventAuthority,
+} from "./production-events";
 import { validateBusPacket } from "./validate";
 import * as crypto from "crypto";
 import {
@@ -837,6 +843,9 @@ export class Agent {
     if (!req || !req.jobId) {
       return;
     }
+    const authority = this.productionEnabled()
+      ? freezeProductionAuthority(req)
+      : undefined;
 
     this.activeJobCount += 1;
     try {
@@ -861,7 +870,7 @@ export class Agent {
           throw new Error("context exceeds max size");
         }
       } catch (err) {
-        await this.publishFailure(ctx, req, err instanceof Error ? err.message : String(err), 0);
+        await this.publishFailure(ctx, req, err instanceof Error ? err.message : String(err), 0, authority);
         return;
       }
 
@@ -869,7 +878,7 @@ export class Agent {
       try {
         raw = JSON.parse(payload.toString("utf-8"));
       } catch (err) {
-        await this.publishFailure(ctx, req, `context decode failed: ${err}`, 0);
+        await this.publishFailure(ctx, req, `context decode failed: ${err}`, 0, authority);
         return;
       }
 
@@ -877,7 +886,7 @@ export class Agent {
       try {
         inputData = spec.inputSchema ? spec.inputSchema.parse(raw) : raw;
       } catch (err) {
-        await this.publishFailure(ctx, req, `input validation failed: ${err}`, 0);
+        await this.publishFailure(ctx, req, `input validation failed: ${err}`, 0, authority);
         return;
       }
 
@@ -907,7 +916,7 @@ export class Agent {
 
       const elapsedMs = Date.now() - start;
       if (error) {
-        await this.publishFailure(ctx, req, error, elapsedMs);
+        await this.publishFailure(ctx, req, error, elapsedMs, authority);
         return;
       }
 
@@ -922,9 +931,9 @@ export class Agent {
         const resultPtr = pointerForKey(resultKey);
 
         this.metrics.onJobCompleted(req.jobId, elapsedMs, "SUCCEEDED");
-        await this.publishResult(ctx, req, resultPtr, elapsedMs);
+        await this.publishResult(ctx, req, resultPtr, elapsedMs, {}, authority);
       } catch (err) {
-        await this.publishFailure(ctx, req, `result write failed: ${err}`, elapsedMs);
+        await this.publishFailure(ctx, req, `result write failed: ${err}`, elapsedMs, authority);
       }
     } finally {
       this.activeJobCount = Math.max(0, this.activeJobCount - 1);
@@ -941,12 +950,18 @@ export class Agent {
     return Buffer.from(JSON.stringify(data), "utf-8");
   }
 
-  private async publishFailure(ctx: Context, req: any, error: string, executionMs: number): Promise<void> {
+  private async publishFailure(
+    ctx: Context,
+    req: any,
+    error: string,
+    executionMs: number,
+    authority?: ProductionEventAuthority,
+  ): Promise<void> {
     this.metrics.onJobFailed(req.jobId, error);
     await this.publishResult(ctx, req, "", executionMs, {
       status: "JOB_STATUS_FAILED",
       errorMessage: error,
-    });
+    }, authority);
   }
 
   private async publishResult(
@@ -954,7 +969,8 @@ export class Agent {
     req: any,
     resultPtr: string,
     executionMs: number,
-    overrides: Record<string, any> = {}
+    overrides: Record<string, any> = {},
+    authority?: ProductionEventAuthority,
   ): Promise<void> {
     if (!this.nc) {
       ctx.log.error("NATS not initialized");
@@ -963,6 +979,9 @@ export class Agent {
     if (!this.busPacketType || !this.jobResultType) {
       ctx.log.error("protobuf types not initialized");
       return;
+    }
+    if (this.productionEnabled() && !authority) {
+      throw new Error("production result requires admitted request authority");
     }
 
     const jrMsg = this.jobResultType.fromObject({
@@ -973,6 +992,7 @@ export class Agent {
       executionMs,
       ...overrides,
     });
+    if (authority) bindProductionEvent(jrMsg, authority);
 
     const out = this.busPacketType.fromObject({
       traceId: ctx.packet.traceId,
@@ -980,9 +1000,21 @@ export class Agent {
       protocolVersion: DEFAULT_PROTOCOL_VERSION,
       createdAt: { seconds: Math.floor(Date.now() / 1000), nanos: 0 },
       jobResult: jrMsg,
+      identity: authority?.identity,
     }) as any;
     prepareOutboundPacket(out, this.trust?.outboundSessionToken() ?? "");
-    const data = encodeOutboundPacket(this.busPacketType, out, this.privateKey);
+    let data: Uint8Array;
+    if (authority) {
+      const config = this.trust?.settings.config;
+      if (!config) throw new Error("production result signing key is unavailable");
+      data = sealProductionEvent(out, this.busPacketType, {
+        privateKey: config.proofPrivateKey,
+        keyId: config.proofKeyId,
+        audience: SUBJECT_RESULT,
+      });
+    } else {
+      data = encodeOutboundPacket(this.busPacketType, out, this.privateKey);
+    }
     await (this.nc.publish(SUBJECT_RESULT, data) as any);
   }
 }

--- a/sdk/node/test/production-admission-support.ts
+++ b/sdk/node/test/production-admission-support.ts
@@ -39,6 +39,9 @@ export interface SignedPacketOptions {
   expiresSeconds?: number;
   expiresNanos?: number;
   contextPtr?: string;
+  dispatchId?: string;
+  dispatchAttempt?: number;
+  assignedWorkerId?: string;
 }
 
 export async function signedRawPacket(opts: SignedPacketOptions = {}): Promise<Buffer> {
@@ -69,6 +72,11 @@ export async function signedRawPacket(opts: SignedPacketOptions = {}): Promise<B
       meta: opts.metaActorId ? { actorId: opts.metaActorId } : undefined,
       env: opts.envTenantId ? { tenant_id: opts.envTenantId } : undefined,
       identity: { tenantId: opts.tenantId ?? "tenant-a", principalId: "principal-a", actorId: opts.actorId },
+      dispatch: opts.dispatchId ? {
+        dispatchId: opts.dispatchId,
+        attempt: opts.dispatchAttempt ?? 0,
+        assignedWorkerId: opts.assignedWorkerId ?? "",
+      } : undefined,
     },
   });
   const unsigned = type.encode(packet).finish();

--- a/sdk/node/test/production-worker-echo.test.ts
+++ b/sdk/node/test/production-worker-echo.test.ts
@@ -1,0 +1,286 @@
+import { expect } from "chai";
+import type { Type } from "protobufjs";
+
+import {
+  freezeProductionAuthority,
+  type ProductionEventAuthority,
+  type ProductionIdentityView,
+  type ProductionDispatchView,
+} from "../src/production-events";
+import { verifyProductionPacket } from "../src/production-signing";
+import { Agent, InMemoryBlobStore } from "../src/runtime";
+import { SUBJECT_RESULT } from "../src/protos";
+import {
+  busPacketType,
+  keyPair,
+  RecordingReplayStore,
+  signedRawPacket,
+} from "./production-admission-support";
+
+interface ProductionRequest {
+  jobId: string;
+  identity?: ProductionIdentityView;
+  dispatch?: ProductionDispatchView;
+}
+
+interface ProductionRuntimeHarness {
+  busPacketType: Type;
+  jobResultType: Type;
+  nc: { publish(subject: string, data: Uint8Array): void };
+  trust?: {
+    productionSessionActive?: boolean;
+    outboundSessionToken(): string;
+    settings: {
+      config: {
+        proofKeyId: string;
+        proofPrivateKey: string;
+        tenantId?: string;
+        expectedSchedulerId?: string;
+      };
+    };
+  };
+  publishResult(
+    context: { packet: { traceId: string }; log: Console },
+    request: ProductionRequest,
+    resultPtr: string,
+    executionMs: number,
+    overrides?: Record<string, unknown>,
+    authority?: ProductionEventAuthority,
+  ): Promise<void>;
+  onMessage(
+    message: { data: Uint8Array; subject: string },
+    spec: {
+      topic: string;
+      handler(context: { job: ProductionRequest }): Promise<Record<string, unknown>>;
+      retries: number;
+    },
+  ): Promise<void>;
+}
+
+interface VerifiedResultPacket {
+  jobResult: {
+    identity: ProductionIdentityView;
+    dispatch: ProductionDispatchView;
+  };
+  identity: ProductionIdentityView;
+  authToken: string;
+  signatureMetadata: { messageId: Uint8Array };
+}
+
+function productionRuntime(agent: Agent): ProductionRuntimeHarness {
+  return agent as unknown as ProductionRuntimeHarness;
+}
+
+describe("production runtime worker echo", () => {
+  it("signs automatic results with frozen identity and dispatch", async () => {
+    const type = await busPacketType();
+    const jobResultType = type.root.lookupType("cordum.agent.v1.JobResult");
+    const published: Array<{ subject: string; data: Buffer }> = [];
+    const agent = new Agent({
+      senderId: "worker-a",
+      store: new InMemoryBlobStore(),
+      productionTrust: {
+        audience: "job.worker.pool-a",
+        tenant: "tenant-a",
+        sender: "scheduler-a",
+        publicKeys: { "scheduler-key": keyPair.publicKey },
+      },
+      replayStore: new RecordingReplayStore(),
+    });
+    const runtime = productionRuntime(agent);
+    runtime.busPacketType = type;
+    runtime.jobResultType = jobResultType;
+    runtime.nc = {
+      publish(subject: string, data: Uint8Array) {
+        published.push({ subject, data: Buffer.from(data) });
+      },
+    };
+    runtime.trust = {
+      outboundSessionToken: () => "session-a",
+      settings: {
+        config: {
+          proofKeyId: "worker-key",
+          proofPrivateKey: keyPair.privateKey,
+        },
+      },
+    };
+    const request = {
+      jobId: "job-a",
+      identity: { tenantId: "tenant-a", principalId: "principal-a", actorId: "actor-a" },
+      dispatch: { dispatchId: "dispatch-a", attempt: 3, assignedWorkerId: "worker-a" },
+    };
+    const authority = freezeProductionAuthority(request);
+    const context = {
+      packet: { traceId: "trace-a" },
+      log: console,
+    };
+
+    await runtime.publishResult(context, request, "redis://result-a", 5, {}, authority);
+    await runtime.publishResult(context, request, "redis://result-b", 6, {}, authority);
+
+    expect(published.map(({ subject }) => subject)).to.deep.equal([SUBJECT_RESULT, SUBJECT_RESULT]);
+    const trust = {
+      audience: SUBJECT_RESULT,
+      tenant: "tenant-a",
+      sender: "worker-a",
+      publicKeys: { "worker-key": keyPair.publicKey },
+    };
+    const packets = published.map(({ data }) =>
+      verifyProductionPacket(data, type, trust) as unknown as VerifiedResultPacket,
+    );
+    expect({ ...packets[0].jobResult.identity }).to.deep.equal(authority.identity);
+    expect({
+      ...packets[0].jobResult.dispatch,
+      attempt: Number(packets[0].jobResult.dispatch.attempt),
+    }).to.deep.equal(authority.dispatch);
+    expect({ ...packets[0].identity }).to.deep.equal(authority.identity);
+    expect(packets[0].authToken).to.equal("session-a");
+    expect(packets[0].signatureMetadata.messageId).to.have.length(16);
+    expect(Buffer.from(packets[0].signatureMetadata.messageId).equals(
+      Buffer.from(packets[1].signatureMetadata.messageId),
+    )).to.equal(false);
+  });
+
+  it("rejects an automatic result for another job", async () => {
+    const type = await busPacketType();
+    const agent = new Agent({
+      senderId: "worker-a",
+      store: new InMemoryBlobStore(),
+      productionTrust: {
+        audience: "job.worker.pool-a",
+        tenant: "tenant-a",
+        sender: "scheduler-a",
+        publicKeys: { "scheduler-key": keyPair.publicKey },
+      },
+      replayStore: new RecordingReplayStore(),
+    });
+    const runtime = productionRuntime(agent);
+    runtime.busPacketType = type;
+    runtime.jobResultType = type.root.lookupType("cordum.agent.v1.JobResult");
+    runtime.nc = { publish() {} };
+    runtime.trust = {
+      outboundSessionToken: () => "session-a",
+      settings: { config: { proofKeyId: "worker-key", proofPrivateKey: keyPair.privateKey } },
+    };
+    const request = {
+      jobId: "job-a",
+      identity: { tenantId: "tenant-a", principalId: "principal-a", actorId: "actor-a" },
+      dispatch: { dispatchId: "dispatch-a", attempt: 3, assignedWorkerId: "worker-a" },
+    };
+
+    let error: unknown;
+    try {
+      await runtime.publishResult(
+        { packet: { traceId: "trace-a" }, log: console },
+        { ...request, jobId: "job-evil" }, "", 0, {}, freezeProductionAuthority(request),
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(String(error)).to.contain("job id");
+  });
+
+  it("requires frozen authority for production results", async () => {
+    const type = await busPacketType();
+    const agent = new Agent({
+      senderId: "worker-a",
+      store: new InMemoryBlobStore(),
+      productionTrust: {
+        audience: "job.worker.pool-a",
+        tenant: "tenant-a",
+        sender: "scheduler-a",
+        publicKeys: { "scheduler-key": keyPair.publicKey },
+      },
+      replayStore: new RecordingReplayStore(),
+    });
+    const runtime = productionRuntime(agent);
+    runtime.busPacketType = type;
+    runtime.jobResultType = type.root.lookupType("cordum.agent.v1.JobResult");
+    runtime.nc = { publish() {} };
+
+    let error: unknown;
+    try {
+      await runtime.publishResult(
+        { packet: { traceId: "trace-a" }, log: console },
+        { jobId: "job-a" },
+        "",
+        0,
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(String(error)).to.contain("requires admitted");
+  });
+
+  it("freezes authority before managed handler mutation", async () => {
+    const type = await busPacketType();
+    const store = new InMemoryBlobStore();
+    const published: Array<{ subject: string; data: Buffer }> = [];
+    const agent = new Agent({
+      senderId: "worker-a",
+      store,
+      productionTrust: {
+        audience: "worker-pool-a",
+        tenant: "tenant-a",
+        sender: "scheduler-1",
+        publicKeys: { k1: keyPair.publicKey },
+      },
+      replayStore: new RecordingReplayStore(),
+    });
+    const runtime = productionRuntime(agent);
+    runtime.busPacketType = type;
+    runtime.jobResultType = type.root.lookupType("cordum.agent.v1.JobResult");
+    runtime.nc = {
+      publish(subject: string, data: Uint8Array) {
+        published.push({ subject, data: Buffer.from(data) });
+      },
+    };
+    runtime.trust = {
+      productionSessionActive: true,
+      outboundSessionToken: () => "session-a",
+      settings: {
+        config: {
+          proofKeyId: "worker-key",
+          proofPrivateKey: keyPair.privateKey,
+          tenantId: "tenant-a",
+          expectedSchedulerId: "scheduler-1",
+        },
+      },
+    };
+    await store.set("ctx:production-echo", Buffer.from("{}"));
+
+    const raw = await signedRawPacket({
+      actorId: "actor-a",
+      contextPtr: "redis://ctx:production-echo",
+      dispatchId: "dispatch-a",
+      dispatchAttempt: 3,
+      assignedWorkerId: "worker-a",
+    });
+    await runtime.onMessage(
+      { data: raw, subject: "worker-pool-a" },
+      {
+        topic: "job.test",
+        retries: 0,
+        async handler(context) {
+          if (context.job.identity) context.job.identity.actorId = "actor-evil";
+          if (context.job.dispatch) context.job.dispatch.attempt = 99;
+          return { ok: true };
+        },
+      },
+    );
+
+    expect(published).to.have.length(1);
+    const packet = verifyProductionPacket(published[0].data, type, {
+      audience: SUBJECT_RESULT,
+      tenant: "tenant-a",
+      sender: "worker-a",
+      publicKeys: { "worker-key": keyPair.publicKey },
+    }) as unknown as VerifiedResultPacket;
+    expect(packet.jobResult.identity.actorId).to.equal("actor-a");
+    expect(packet.jobResult.dispatch).to.include({
+      dispatchId: "dispatch-a",
+      assignedWorkerId: "worker-a",
+    });
+    expect(Number(packet.jobResult.dispatch.attempt)).to.equal(3);
+  });
+});

--- a/sdk/python/cap/runtime.py
+++ b/sdk/python/cap/runtime.py
@@ -38,6 +38,13 @@ from cap.production_signing import (
     verify_production_packet,
 )
 from cap.production_replay import ReplayConflictError, ReplayOutcome, ReplayStore, ReplayStoreUnavailableError
+from cap.production_events import (
+    ProductionEventAuthority,
+    ProductionEventConflictError,
+    bind_production_event,
+    freeze_production_authority,
+    seal_production_event,
+)
 from cap.production_validation import IdentityMismatchError, validate_identity_binding
 from cap.validate import validate_bus_packet
 from cap.worker_trust import WorkerTrustConfig, WorkerTrustMode
@@ -1151,6 +1158,9 @@ class Agent:
         req = packet.job_request
         if not req.job_id:
             return
+        authority = (
+            freeze_production_authority(req) if self._production_enabled() else None
+        )
 
         self._active_jobs.add(req.job_id)
         try:
@@ -1183,19 +1193,33 @@ class Agent:
                 if self._max_context_bytes is not None and len(payload) > self._max_context_bytes:
                     raise ValueError("context exceeds max size")
             except Exception as exc:
-                await self._publish_failure(ctx, req, str(exc), execution_ms=0)
+                await self._publish_failure(
+                    ctx, req, str(exc), execution_ms=0, authority=authority
+                )
                 return
 
             try:
                 raw = json.loads(payload.decode("utf-8"))
             except Exception as exc:
-                await self._publish_failure(ctx, req, f"context decode failed: {exc}", execution_ms=0)
+                await self._publish_failure(
+                    ctx,
+                    req,
+                    f"context decode failed: {exc}",
+                    execution_ms=0,
+                    authority=authority,
+                )
                 return
 
             try:
                 input_data = self._validate_input(spec, raw)
             except Exception as exc:
-                await self._publish_failure(ctx, req, f"input validation failed: {exc}", execution_ms=0)
+                await self._publish_failure(
+                    ctx,
+                    req,
+                    f"input validation failed: {exc}",
+                    execution_ms=0,
+                    authority=authority,
+                )
                 return
 
             # Build middleware chain: outermost first, terminal calls handler.
@@ -1234,7 +1258,9 @@ class Agent:
 
             elapsed_ms = int((time.monotonic() - start_time) * 1000)
             if error is not None:
-                await self._publish_failure(ctx, req, error, execution_ms=elapsed_ms)
+                await self._publish_failure(
+                    ctx, req, error, execution_ms=elapsed_ms, authority=authority
+                )
                 return
 
             try:
@@ -1245,7 +1271,13 @@ class Agent:
                 await self._with_timeout(store.set(result_key, result_payload), "result write")
                 result_ptr = pointer_for_key(result_key)
             except Exception as exc:
-                await self._publish_failure(ctx, req, f"result write failed: {exc}", execution_ms=elapsed_ms)
+                await self._publish_failure(
+                    ctx,
+                    req,
+                    f"result write failed: {exc}",
+                    execution_ms=elapsed_ms,
+                    authority=authority,
+                )
                 return
 
             result = job_pb2.JobResult(
@@ -1255,7 +1287,7 @@ class Agent:
                 worker_id=self._sender_id,
                 execution_ms=elapsed_ms,
             )
-            await self._publish_result(ctx, result)
+            await self._publish_result(ctx, result, authority)
             safe_metrics_call(
                 self._logger,
                 lambda: self._metrics.on_job_completed(
@@ -1294,6 +1326,7 @@ class Agent:
         req: job_pb2.JobRequest,
         error: str,
         execution_ms: int,
+        authority: Optional[ProductionEventAuthority] = None,
     ) -> None:
         result = job_pb2.JobResult(
             job_id=req.job_id,
@@ -1302,16 +1335,30 @@ class Agent:
             worker_id=self._sender_id,
             execution_ms=execution_ms,
         )
-        await self._publish_result(ctx, result)
+        await self._publish_result(ctx, result, authority)
         safe_metrics_call(
             self._logger,
             lambda: self._metrics.on_job_failed(req.job_id, error),
         )
 
-    async def _publish_result(self, ctx: Context, result: job_pb2.JobResult) -> None:
+    async def _publish_result(
+        self,
+        ctx: Context,
+        result: job_pb2.JobResult,
+        authority: Optional[ProductionEventAuthority] = None,
+    ) -> None:
         if self._nc is None:
             ctx.logger.error("NATS not initialized")
             return
+        if self._production_enabled() and authority is None:
+            raise ProductionEventConflictError(
+                "production result requires admitted request authority"
+            )
+
+        bound_result = job_pb2.JobResult()
+        bound_result.CopyFrom(result)
+        if authority is not None:
+            bind_production_event(bound_result, authority)
         packet = buspacket_pb2.BusPacket()
         packet.trace_id = ctx.packet.trace_id
         packet.sender_id = self._sender_id
@@ -1319,17 +1366,32 @@ class Agent:
         ts = timestamp_pb2.Timestamp()
         ts.GetCurrentTime()
         packet.created_at.CopyFrom(ts)
-        packet.job_result.CopyFrom(result)
-        outgoing = finalize_packet(
-            packet,
-            self._private_key,
-            session_token=self._outbound_session_token(),
-        )
+        packet.job_result.CopyFrom(bound_result)
+        if authority is not None:
+            packet.identity.CopyFrom(authority.identity)
+            packet.auth_token = self._outbound_session_token()
+            settings = self._trust_settings
+            config = settings.config if settings is not None else None
+            if config is None:
+                raise ProductionEventConflictError(
+                    "production result signing key is unavailable"
+                )
+            raw = seal_production_event(
+                packet,
+                key=config.proof_private_key,
+                key_id=config.proof_key_id,
+                audience=SUBJECT_RESULT,
+            )
+        else:
+            outgoing = finalize_packet(
+                packet,
+                self._private_key,
+                session_token=self._outbound_session_token(),
+            )
+            raw = outgoing.SerializeToString(deterministic=True)
 
         await self._with_timeout(
-            self._nc.publish(
-                SUBJECT_RESULT, outgoing.SerializeToString(deterministic=True)
-            ),
+            self._nc.publish(SUBJECT_RESULT, raw),
             "result publish",
         )
 

--- a/sdk/python/tests/test_production_worker_echo.py
+++ b/sdk/python/tests/test_production_worker_echo.py
@@ -1,0 +1,168 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from cap.pb.cordum.agent.v1 import buspacket_pb2, job_pb2
+from cap.production_events import (
+    ProductionEventAuthority,
+    ProductionEventConflictError,
+    freeze_production_authority,
+)
+from cap.production_replay import InMemoryReplayStore
+from cap.production_signing import ProductionTrust, verify_production_packet
+from cap.runtime import Agent, Context, InMemoryBlobStore
+from cap.subjects import SUBJECT_RESULT
+from cap.worker_trust import WorkerTrustMode
+
+
+class RecordingNats:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, payload))
+
+
+def production_context() -> tuple[Context, ProductionEventAuthority]:
+    identity = job_pb2.IdentityBinding(
+        tenant_id="tenant-a", principal_id="principal-a", actor_id="actor-a"
+    )
+    dispatch = job_pb2.DispatchIdentity(
+        dispatch_id="dispatch-a", attempt=3, assigned_worker_id="worker-a"
+    )
+    request = job_pb2.JobRequest(
+        job_id="job-a", topic="job.test", context_ptr="redis://ctx:production-echo"
+    )
+    request.identity.CopyFrom(identity)
+    request.dispatch.CopyFrom(dispatch)
+    packet = buspacket_pb2.BusPacket(trace_id="trace-a", sender_id="scheduler-a")
+    packet.job_request.CopyFrom(request)
+    packet.identity.CopyFrom(identity)
+    logger = logging.LoggerAdapter(logging.getLogger("production-worker-echo"), {})
+    return Context(job=request, packet=packet, logger=logger), freeze_production_authority(request)
+
+
+def production_agent(worker_key: ec.EllipticCurvePrivateKey) -> Agent:
+    scheduler_key = ec.generate_private_key(ec.SECP256R1())
+    trust = ProductionTrust(
+        audience="job.worker.pool-a",
+        tenant="tenant-a",
+        sender="scheduler-a",
+        public_keys={"scheduler-key": scheduler_key.public_key()},
+    )
+    agent = Agent(
+        sender_id="worker-a",
+        production_trust=trust,
+        replay_store=InMemoryReplayStore(),
+    )
+    agent._nc = RecordingNats()
+    agent._store = InMemoryBlobStore()
+    agent._trust_settings = SimpleNamespace(
+        mode=WorkerTrustMode.ENFORCE,
+        config=SimpleNamespace(
+            proof_key_id="worker-key", proof_private_key=worker_key
+        )
+    )
+    agent._worker_trust = SimpleNamespace(session_token=lambda: "session-a")
+    agent._trust_admitting = True
+    return agent
+
+
+def test_runtime_result_echoes_and_signs_frozen_authority() -> None:
+    key = ec.generate_private_key(ec.SECP256R1())
+    agent = production_agent(key)
+    ctx, authority = production_context()
+
+    async def publish_results() -> None:
+        await agent._publish_result(
+            ctx,
+            job_pb2.JobResult(
+                status=job_pb2.JOB_STATUS_SUCCEEDED, worker_id="worker-a"
+            ),
+            authority,
+        )
+        await agent._publish_result(
+            ctx,
+            job_pb2.JobResult(
+                status=job_pb2.JOB_STATUS_SUCCEEDED, worker_id="worker-a"
+            ),
+            authority,
+        )
+
+    asyncio.run(publish_results())
+
+    published = agent._nc.published
+    assert [subject for subject, _ in published] == [SUBJECT_RESULT, SUBJECT_RESULT]
+    verify = ProductionTrust(
+        audience=SUBJECT_RESULT,
+        tenant="tenant-a",
+        sender="worker-a",
+        public_keys={"worker-key": key.public_key()},
+    )
+    packets = [verify_production_packet(raw, verify) for _, raw in published]
+    assert packets[0].job_result.identity == authority.identity
+    assert packets[0].job_result.dispatch == authority.dispatch
+    assert packets[0].identity == authority.identity
+    assert packets[0].auth_token == "session-a"
+    assert len(packets[0].signature_metadata.message_id) == 16
+    assert packets[0].signature_metadata.message_id != packets[1].signature_metadata.message_id
+
+
+def test_runtime_result_rejects_conflicting_job_id() -> None:
+    agent = production_agent(ec.generate_private_key(ec.SECP256R1()))
+    ctx, authority = production_context()
+
+    with pytest.raises(ProductionEventConflictError, match="job id"):
+        asyncio.run(
+            agent._publish_result(
+                ctx,
+                job_pb2.JobResult(job_id="job-evil", worker_id="worker-a"),
+                authority,
+            )
+        )
+
+
+def test_runtime_result_requires_frozen_authority_in_production() -> None:
+    agent = production_agent(ec.generate_private_key(ec.SECP256R1()))
+    ctx, _ = production_context()
+
+    with pytest.raises(ProductionEventConflictError, match="requires admitted"):
+        asyncio.run(
+            agent._publish_result(
+                ctx,
+                job_pb2.JobResult(job_id="job-a", worker_id="worker-a"),
+            )
+        )
+
+
+def test_runtime_freezes_authority_before_handler_mutation() -> None:
+    key = ec.generate_private_key(ec.SECP256R1())
+    agent = production_agent(key)
+    ctx, authority = production_context()
+
+    @agent.job("job.test")
+    async def mutate_request(context: Context, _data: object) -> dict[str, bool]:
+        context.job.identity.actor_id = "actor-evil"
+        context.job.dispatch.attempt = 99
+        return {"ok": True}
+
+    async def execute_handler() -> None:
+        await agent._store.set("ctx:production-echo", b"{}")
+        await agent._on_msg(
+            SimpleNamespace(data=b""), agent._handlers["job.test"], ctx.packet
+        )
+
+    asyncio.run(execute_handler())
+
+    verify = ProductionTrust(
+        audience=SUBJECT_RESULT,
+        tenant="tenant-a",
+        sender="worker-a",
+        public_keys={"worker-key": key.public_key()},
+    )
+    packet = verify_production_packet(agent._nc.published[0][1], verify)
+    assert packet.job_result.identity == authority.identity
+    assert packet.job_result.dispatch == authority.dispatch


### PR DESCRIPTION
## Summary
- freeze admitted identity and dispatch authority before Python/Node managed handlers run
- bind automatic success/failure results to that authority and fail closed on conflicts
- attach the authenticated worker session and sign terminal results with fresh subject-bound CAP-PRODUCTION metadata

## Verification
- Python focused tests: 4 passed, three consecutive runs
- Python source + real-NATS suite: 520 passed
- Python clean wheel/sdist artifact suite: 13 passed
- Node focused tests: 4 passing, three consecutive runs
- Node full suite: 369 passing, 2 pending
- Node package build, installed-package verification, and publint: passed

## Scope
No protobuf or generated wire artifact changed. Existing shared Result/Progress/Cancel helpers remain the authority/sealing implementation; this PR wires managed terminal Results into that path.
