### PR TITLE
feat(go): land bounded ResourceRef registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Cordum Agent Protocol and its SDKs are documented her
 
 Entries are grouped by SDK release tag. Wire schema changes (protobuf field additions or semantic changes) are prefixed with **[WIRE]**. See [spec/17-versioning-policy.md](spec/17-versioning-policy.md) for the full versioning policy.
 
+## Development
+
+- **Go SDK ResourceRef registry:** added an immutable registry of operator-installed
+  resolver/externalizer backends. Resolution and externalization require authenticated
+  tenant/job context, enforce per-backend streaming size bounds, independently verify media
+  type, size, SHA-256, purpose, and expiry, and expose no generic URL/file fallback or
+  embedded-credential path. Resolved bytes are opaque and clone-returning; cancellation and
+  backend failures fail closed with bounded typed errors.
+
 ## v2.16.1 — 2026-07-22
 
 - **CI (no source change):** fixed two publish-workflow bugs that had been dormant since v2.14.0 (neither `publish-go.yml` nor `publish-python.yml` runs outside an actual GitHub Release, and none had been created since). `publish-python.yml`'s mandatory real-NATS gate failed to even collect `test_production_admission_nats.py` (`from tests.docker_nats_support import ...` only resolved when invoked with `sdk/python` as the working directory, not from the repo root as the workflow does) — added `sdk/python/tests/conftest.py` to fix path resolution regardless of invocation directory. `publish-go.yml`'s stub-regeneration step called the pre-hermetic-codegen `tools/make_protos.sh` invocation (no mode flag, custom `CAP_OUT_GO` output directory) that PR #81's rewrite made incompatible; replaced it with a direct test of the already-tracked, already-freshness-checked `cordum/agent/v1/*.pb.go` output.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -282,6 +282,18 @@ actual subject, authenticated tenant/sender, signature-covered session token,
 message ID, and exact signed-body digest. Its state is private, its accessors
 return copies, and the externally constructible zero value carries no trust.
 
+Applications that materialize structured `ResourceRef` values can install a
+sealed `capsdk.ResourceRegistry`. Each registration pairs one exact resolver ID
+with operator-configured resolver and externalizer backends plus a streaming
+byte limit. `Resolve` and `Externalize` require a `TrustedResourceContext`
+derived from the authenticated local tenant/job authority; reference fields
+never supply or override those values. The registry rechecks expiry, media type,
+size, SHA-256, purpose, and backend identity and returns clone-safe verified
+bytes. It has no generic URL, filesystem, redirect, or credential fallback.
+Managed workers validate the configured resolver IDs but do not fetch resource
+content implicitly; handlers and adapters explicitly call the registry at their
+trusted boundary.
+
 `ManagedReplayStore` is a lease-and-outcome contract, not a process-local
 duplicate cache. It must durably claim, renew, complete, and abort work. A
 completed logical result is replayed with a fresh session token and production

--- a/sdk/go/production_resource_externalize.go
+++ b/sdk/go/production_resource_externalize.go
@@ -36,6 +36,9 @@ func (registry *ResourceRegistry) Externalize(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if !expiresAt.After(registry.currentTime()) {
+		return nil, ErrResourceExpired
+	}
 	if len(content) == 0 {
 		return nil, ErrResourceSizeMismatch
 	}
@@ -78,7 +81,7 @@ func (registry *ResourceRegistry) externalizeInputs(
 		return resourceBackend{}, time.Time{}, ErrInvalidResourceRegistry
 	}
 	if ctx == nil {
-		return resourceBackend{}, time.Time{}, ErrInvalidTrustedResourceContext
+		return resourceBackend{}, time.Time{}, ErrResourceContextRequired
 	}
 	if err := ctx.Err(); err != nil {
 		return resourceBackend{}, time.Time{}, err

--- a/sdk/go/production_resource_externalize.go
+++ b/sdk/go/production_resource_externalize.go
@@ -33,6 +33,9 @@ func (registry *ResourceRegistry) Externalize(
 	if err != nil {
 		return nil, err
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(content) == 0 {
 		return nil, ErrResourceSizeMismatch
 	}

--- a/sdk/go/production_resource_externalize.go
+++ b/sdk/go/production_resource_externalize.go
@@ -1,0 +1,161 @@
+package capsdk
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"io"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Externalize reads content through a strict installed bound and asks the
+// explicitly selected backend to store it. Every returned reference field is
+// independently checked before a deep clone is returned.
+func (registry *ResourceRegistry) Externalize(
+	ctx context.Context,
+	backendID string,
+	reader io.Reader,
+	mediaType string,
+	purpose string,
+	expiresAt time.Time,
+	trusted TrustedResourceContext,
+) (*agentv1.ResourceRef, error) {
+	backend, now, err := registry.externalizeInputs(ctx, backendID, mediaType, purpose, expiresAt, trusted)
+	if err != nil {
+		return nil, err
+	}
+	content, err := readBounded(ctx, reader, backend.maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 {
+		return nil, ErrResourceSizeMismatch
+	}
+	request := externalizeRequest(content, mediaType, purpose, expiresAt, trusted)
+	ref, err := backend.externalizer.Externalize(ctx, request)
+	if err != nil {
+		return nil, collapseBackendError(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !expiresAt.After(registry.currentTime()) {
+		return nil, ErrResourceExpired
+	}
+	return registry.validateExternalizedRef(ref, backendID, request, now)
+}
+
+// ExternalizeBytes is a convenience wrapper over Externalize.
+func (registry *ResourceRegistry) ExternalizeBytes(
+	ctx context.Context,
+	backendID string,
+	content []byte,
+	mediaType string,
+	purpose string,
+	expiresAt time.Time,
+	trusted TrustedResourceContext,
+) (*agentv1.ResourceRef, error) {
+	return registry.Externalize(ctx, backendID, bytes.NewReader(content), mediaType, purpose, expiresAt, trusted)
+}
+
+func (registry *ResourceRegistry) externalizeInputs(
+	ctx context.Context,
+	backendID string,
+	mediaType string,
+	purpose string,
+	expiresAt time.Time,
+	trusted TrustedResourceContext,
+) (resourceBackend, time.Time, error) {
+	if !registry.valid() {
+		return resourceBackend{}, time.Time{}, ErrInvalidResourceRegistry
+	}
+	if ctx == nil {
+		return resourceBackend{}, time.Time{}, ErrInvalidTrustedResourceContext
+	}
+	if err := ctx.Err(); err != nil {
+		return resourceBackend{}, time.Time{}, err
+	}
+	if err := validateTrustedResourceContext(trusted); err != nil {
+		return resourceBackend{}, time.Time{}, err
+	}
+	if !validResourceIdentifier(backendID, MaxResourceIdentifierBytes, resourceIDPattern) {
+		return resourceBackend{}, time.Time{}, ErrResourceExternalizerUnavailable
+	}
+	backend, installed := registry.backends[backendID]
+	if !installed {
+		return resourceBackend{}, time.Time{}, ErrResourceExternalizerUnavailable
+	}
+	if !validResourceIdentifier(mediaType, MaxResourceMediaTypeBytes, resourceMediaPattern) ||
+		!validResourceIdentifier(purpose, MaxResourcePurposeBytes, resourcePurposePattern) {
+		return resourceBackend{}, time.Time{}, ErrInvalidResourceRef
+	}
+	expiresAt = expiresAt.UTC()
+	timestamp := timestamppb.New(expiresAt)
+	now := registry.currentTime()
+	if timestamp.CheckValid() != nil {
+		return resourceBackend{}, time.Time{}, ErrInvalidResourceRef
+	}
+	if !expiresAt.After(now) {
+		return resourceBackend{}, time.Time{}, ErrResourceExpired
+	}
+	return backend, now, nil
+}
+
+func externalizeRequest(
+	content []byte,
+	mediaType string,
+	purpose string,
+	expiresAt time.Time,
+	trusted TrustedResourceContext,
+) ResourceExternalizeRequest {
+	digest := sha256.Sum256(content)
+	return ResourceExternalizeRequest{
+		TrustedContext: trusted, Content: append([]byte(nil), content...),
+		MediaType: mediaType, Purpose: purpose, ExpiresAt: expiresAt.UTC(),
+		SizeBytes: uint64(len(content)), SHA256: digest,
+	}
+}
+
+func (registry *ResourceRegistry) validateExternalizedRef(
+	ref *agentv1.ResourceRef,
+	backendID string,
+	request ResourceExternalizeRequest,
+	validatedAt time.Time,
+) (*agentv1.ResourceRef, error) {
+	if ref == nil {
+		return nil, ErrResourceMetadataMismatch
+	}
+	snapshot := proto.Clone(ref).(*agentv1.ResourceRef)
+	if !externalizedMetadataMatches(snapshot, backendID, request) {
+		return nil, ErrResourceMetadataMismatch
+	}
+	if err := ValidateResourceRefAt(snapshot, registry.ids, validatedAt); err != nil {
+		return nil, err
+	}
+	return proto.Clone(snapshot).(*agentv1.ResourceRef), nil
+}
+
+func externalizedMetadataMatches(
+	ref *agentv1.ResourceRef,
+	backendID string,
+	request ResourceExternalizeRequest,
+) bool {
+	if ref.GetResolverId() != backendID || ref.GetMediaType() != request.MediaType {
+		return false
+	}
+	if ref.GetPurpose() != request.Purpose || ref.GetSizeBytes() != request.SizeBytes {
+		return false
+	}
+	if subtle.ConstantTimeCompare(ref.GetSha256(), request.SHA256[:]) != 1 {
+		return false
+	}
+	if ref.GetExpiresAt() == nil || ref.GetExpiresAt().CheckValid() != nil {
+		return false
+	}
+	return ref.GetExpiresAt().AsTime().Equal(request.ExpiresAt)
+}

--- a/sdk/go/production_resource_registry.go
+++ b/sdk/go/production_resource_registry.go
@@ -57,10 +57,25 @@ type ResourceResolveResult struct {
 }
 
 // ResolvedResource contains bytes that passed expiry, type, size, and digest
-// checks. Content is owned by the caller.
+// checks. Its representation is opaque so only Resolve can create a populated
+// value; accessors return caller-owned data.
 type ResolvedResource struct {
-	Content   []byte
-	MediaType string
+	content   []byte
+	mediaType string
+}
+
+// Content returns a defensive copy of the verified resource bytes.
+func (resource ResolvedResource) Content() []byte {
+	return append([]byte(nil), resource.content...)
+}
+
+// MediaType returns the exact verified media type.
+func (resource ResolvedResource) MediaType() string {
+	return resource.mediaType
+}
+
+func newResolvedResource(content []byte, mediaType string) ResolvedResource {
+	return ResolvedResource{content: append([]byte(nil), content...), mediaType: mediaType}
 }
 
 // ResourceExternalizeRequest contains bounded content and trusted local
@@ -82,7 +97,8 @@ type ResourceResolverBackend interface {
 }
 
 // ResourceExternalizerBackend stores bounded content and returns a complete
-// ResourceRef. The registry independently validates every returned field.
+// ResourceRef. It must honor ctx. The registry independently validates every
+// returned field.
 type ResourceExternalizerBackend interface {
 	Externalize(context.Context, ResourceExternalizeRequest) (*agentv1.ResourceRef, error)
 }

--- a/sdk/go/production_resource_registry.go
+++ b/sdk/go/production_resource_registry.go
@@ -18,6 +18,7 @@ const (
 
 var (
 	ErrInvalidResourceRegistry         = errors.New("capsdk: invalid resource registry")
+	ErrResourceContextRequired         = errors.New("capsdk: resource operation context required")
 	ErrInvalidTrustedResourceContext   = errors.New("capsdk: invalid trusted resource context")
 	ErrResourceResolverUnavailable     = errors.New("capsdk: resource resolver unavailable")
 	ErrResourceExternalizerUnavailable = errors.New("capsdk: resource externalizer unavailable")

--- a/sdk/go/production_resource_registry.go
+++ b/sdk/go/production_resource_registry.go
@@ -1,0 +1,196 @@
+package capsdk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"regexp"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+)
+
+const (
+	MaxTrustedTenantIDBytes = 128
+	MaxTrustedJobIDBytes    = 256
+)
+
+var (
+	ErrInvalidResourceRegistry         = errors.New("capsdk: invalid resource registry")
+	ErrInvalidTrustedResourceContext   = errors.New("capsdk: invalid trusted resource context")
+	ErrResourceResolverUnavailable     = errors.New("capsdk: resource resolver unavailable")
+	ErrResourceExternalizerUnavailable = errors.New("capsdk: resource externalizer unavailable")
+	ErrResourceBackendUnavailable      = errors.New("capsdk: resource backend unavailable")
+	ErrResourceExpired                 = errors.New("capsdk: resource expired")
+	ErrResourceTooLarge                = errors.New("capsdk: resource exceeds installed limit")
+	ErrResourceSizeMismatch            = errors.New("capsdk: resource size mismatch")
+	ErrResourceMediaTypeMismatch       = errors.New("capsdk: resource media type mismatch")
+	ErrResourceDigestMismatch          = errors.New("capsdk: resource digest mismatch")
+	ErrResourceMetadataMismatch        = errors.New("capsdk: externalized resource metadata mismatch")
+
+	trustedTenantPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	trustedJobPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:@\-\[\]]*$`)
+)
+
+// TrustedResourceContext comes from authenticated local authority. A
+// ResourceRef never supplies or overrides these values.
+type TrustedResourceContext struct {
+	TenantID string
+	JobID    string
+}
+
+// ResourceResolveRequest is the validated, immutable request sent to an
+// explicitly installed resolver.
+type ResourceResolveRequest struct {
+	TrustedContext    TrustedResourceContext
+	URI               string
+	MediaType         string
+	Purpose           string
+	DeclaredSizeBytes uint64
+}
+
+// ResourceResolveResult is the streaming result returned by a resolver.
+type ResourceResolveResult struct {
+	Body      io.ReadCloser
+	MediaType string
+}
+
+// ResolvedResource contains bytes that passed expiry, type, size, and digest
+// checks. Content is owned by the caller.
+type ResolvedResource struct {
+	Content   []byte
+	MediaType string
+}
+
+// ResourceExternalizeRequest contains bounded content and trusted local
+// authority for an explicitly installed externalizer.
+type ResourceExternalizeRequest struct {
+	TrustedContext TrustedResourceContext
+	Content        []byte
+	MediaType      string
+	Purpose        string
+	ExpiresAt      time.Time
+	SizeBytes      uint64
+	SHA256         [32]byte
+}
+
+// ResourceResolverBackend fetches only from its operator-configured store. It
+// must honor ctx and must not interpret ResourceRef values as credentials.
+type ResourceResolverBackend interface {
+	Resolve(context.Context, ResourceResolveRequest) (ResourceResolveResult, error)
+}
+
+// ResourceExternalizerBackend stores bounded content and returns a complete
+// ResourceRef. The registry independently validates every returned field.
+type ResourceExternalizerBackend interface {
+	Externalize(context.Context, ResourceExternalizeRequest) (*agentv1.ResourceRef, error)
+}
+
+// ResourceBackendRegistration installs one paired resolver/externalizer under
+// an exact canonical ID.
+type ResourceBackendRegistration struct {
+	ID           string
+	MaxBytes     uint64
+	Resolver     ResourceResolverBackend
+	Externalizer ResourceExternalizerBackend
+}
+
+type resourceBackend struct {
+	maxBytes     uint64
+	resolver     ResourceResolverBackend
+	externalizer ResourceExternalizerBackend
+}
+
+// ResourceRegistry is an immutable snapshot of operator-installed backends.
+type ResourceRegistry struct {
+	now      func() time.Time
+	backends map[string]resourceBackend
+	ids      []string
+}
+
+// NewResourceRegistry snapshots registrations. A nil clock uses time.Now.
+func NewResourceRegistry(now func() time.Time, registrations ...ResourceBackendRegistration) (*ResourceRegistry, error) {
+	if len(registrations) == 0 {
+		return nil, ErrInvalidResourceRegistry
+	}
+	if now == nil {
+		now = time.Now
+	}
+	registry := &ResourceRegistry{
+		now: now, backends: make(map[string]resourceBackend, len(registrations)),
+		ids: make([]string, 0, len(registrations)),
+	}
+	for _, registration := range registrations {
+		if err := registry.addRegistration(registration); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+func (registry *ResourceRegistry) addRegistration(registration ResourceBackendRegistration) error {
+	if !validResourceIdentifier(registration.ID, MaxResourceIdentifierBytes, resourceIDPattern) {
+		return ErrInvalidResourceRegistry
+	}
+	if registration.MaxBytes == 0 || registration.MaxBytes > MaxResourceSizeBytes {
+		return ErrInvalidResourceRegistry
+	}
+	if resolverBackendIsNil(registration.Resolver) || externalizerBackendIsNil(registration.Externalizer) {
+		return ErrInvalidResourceRegistry
+	}
+	if _, duplicate := registry.backends[registration.ID]; duplicate {
+		return ErrInvalidResourceRegistry
+	}
+	registry.backends[registration.ID] = resourceBackend{
+		maxBytes: registration.MaxBytes,
+		resolver: registration.Resolver, externalizer: registration.Externalizer,
+	}
+	registry.ids = append(registry.ids, registration.ID)
+	return nil
+}
+
+func (registry *ResourceRegistry) valid() bool {
+	return registry != nil && registry.now != nil && len(registry.backends) > 0 && len(registry.ids) > 0
+}
+
+func (registry *ResourceRegistry) currentTime() time.Time {
+	return registry.now().UTC()
+}
+
+func validateTrustedResourceContext(trusted TrustedResourceContext) error {
+	if !validTrustedValue(trusted.TenantID, MaxTrustedTenantIDBytes, trustedTenantPattern) {
+		return ErrInvalidTrustedResourceContext
+	}
+	if !validTrustedValue(trusted.JobID, MaxTrustedJobIDBytes, trustedJobPattern) {
+		return ErrInvalidTrustedResourceContext
+	}
+	return nil
+}
+
+func validTrustedValue(value string, limit int, pattern *regexp.Regexp) bool {
+	return value != "" && len(value) <= limit && pattern.MatchString(value)
+}
+
+func resolverBackendIsNil(backend ResourceResolverBackend) bool {
+	if backend == nil {
+		return true
+	}
+	return nilReflectValue(reflect.ValueOf(backend))
+}
+
+func externalizerBackendIsNil(backend ResourceExternalizerBackend) bool {
+	if backend == nil {
+		return true
+	}
+	return nilReflectValue(reflect.ValueOf(backend))
+}
+
+func nilReflectValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/sdk/go/production_resource_registry_external_test.go
+++ b/sdk/go/production_resource_registry_external_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"io"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -95,4 +96,24 @@ func trustedContext() capsdk.TrustedResourceContext {
 
 func fixedClock(now time.Time) func() time.Time {
 	return func() time.Time { return now }
+}
+
+func TestResolvedResourceAPIIsOpaque(t *testing.T) {
+	resourceType := reflect.TypeOf(capsdk.ResolvedResource{})
+	for index := 0; index < resourceType.NumField(); index++ {
+		field := resourceType.Field(index)
+		if field.IsExported() {
+			t.Fatalf("ResolvedResource field %q is externally forgeable", field.Name)
+		}
+	}
+}
+
+func TestResolvedResourceZeroValueExposesNoVerifiedData(t *testing.T) {
+	var resource capsdk.ResolvedResource
+	if content := resource.Content(); content != nil {
+		t.Fatalf("zero-value Content() = %q", content)
+	}
+	if mediaType := resource.MediaType(); mediaType != "" {
+		t.Fatalf("zero-value MediaType() = %q", mediaType)
+	}
 }

--- a/sdk/go/production_resource_registry_external_test.go
+++ b/sdk/go/production_resource_registry_external_test.go
@@ -1,0 +1,98 @@
+package capsdk_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+	capsdk "github.com/cordum-io/cap/v2/sdk/go"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type resolverFunc func(context.Context, capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error)
+
+func (fn resolverFunc) Resolve(
+	ctx context.Context,
+	request capsdk.ResourceResolveRequest,
+) (capsdk.ResourceResolveResult, error) {
+	return fn(ctx, request)
+}
+
+type externalizerFunc func(context.Context, capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error)
+
+func (fn externalizerFunc) Externalize(
+	ctx context.Context,
+	request capsdk.ResourceExternalizeRequest,
+) (*agentv1.ResourceRef, error) {
+	return fn(ctx, request)
+}
+
+type backendHarness struct {
+	mu           sync.Mutex
+	content      []byte
+	mediaType    string
+	resolveCalls int
+	externalize  func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error)
+}
+
+func (backend *backendHarness) resolver() capsdk.ResourceResolverBackend {
+	return resolverFunc(func(_ context.Context, _ capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		backend.resolveCalls++
+		body := append([]byte(nil), backend.content...)
+		return capsdk.ResourceResolveResult{Body: io.NopCloser(bytes.NewReader(body)), MediaType: backend.mediaType}, nil
+	})
+}
+
+func (backend *backendHarness) externalizer() capsdk.ResourceExternalizerBackend {
+	return externalizerFunc(func(_ context.Context, request capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		if backend.externalize != nil {
+			return backend.externalize(request)
+		}
+		return refFromRequest("memory", "memory://objects/item", request), nil
+	})
+}
+
+func newRegistry(t *testing.T, now func() time.Time, backend *backendHarness, maxBytes uint64) *capsdk.ResourceRegistry {
+	t.Helper()
+	registry, err := capsdk.NewResourceRegistry(now, capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: maxBytes,
+		Resolver: backend.resolver(), Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatalf("NewResourceRegistry() error = %v", err)
+	}
+	return registry
+}
+
+func validRef(content []byte, expires time.Time) *agentv1.ResourceRef {
+	digest := sha256.Sum256(content)
+	return &agentv1.ResourceRef{
+		ResolverId: "memory", Uri: "memory://objects/item", Sha256: digest[:],
+		MediaType: "application/json", SizeBytes: uint64(len(content)),
+		ExpiresAt: timestamppb.New(expires), Purpose: "job-input",
+	}
+}
+
+func refFromRequest(id, uri string, request capsdk.ResourceExternalizeRequest) *agentv1.ResourceRef {
+	digest := append([]byte(nil), request.SHA256[:]...)
+	return &agentv1.ResourceRef{
+		ResolverId: id, Uri: uri, Sha256: digest, MediaType: request.MediaType,
+		SizeBytes: request.SizeBytes, ExpiresAt: timestamppb.New(request.ExpiresAt),
+		Purpose: request.Purpose,
+	}
+}
+
+func trustedContext() capsdk.TrustedResourceContext {
+	return capsdk.TrustedResourceContext{TenantID: "tenant-a", JobID: "job-7"}
+}
+
+func fixedClock(now time.Time) func() time.Time {
+	return func() time.Time { return now }
+}

--- a/sdk/go/production_resource_registry_externalize_test.go
+++ b/sdk/go/production_resource_registry_externalize_test.go
@@ -146,6 +146,22 @@ func TestResourceRegistryExternalizeRejectsCancellationAndExpiry(t *testing.T) {
 	}
 }
 
+func TestResourceRegistryExternalizeRejectsCancellationAtEndOfRead(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	called := false
+	backend := &backendHarness{externalize: func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		called = true
+		return nil, nil
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &cancelOnReadCloser{Reader: bytes.NewReader([]byte("payload")), cancel: cancel}
+	_, err := registry.Externalize(ctx, "memory", reader, "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, context.Canceled) || called {
+		t.Fatalf("Externalize() error=%v backend-called=%v", err, called)
+	}
+}
+
 func TestResourceRegistryExternalizeRejectsExpiryDuringBackendCall(t *testing.T) {
 	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	times := []time.Time{base, base.Add(2 * time.Second)}

--- a/sdk/go/production_resource_registry_externalize_test.go
+++ b/sdk/go/production_resource_registry_externalize_test.go
@@ -1,0 +1,163 @@
+package capsdk_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+	capsdk "github.com/cordum-io/cap/v2/sdk/go"
+)
+
+func TestResourceRegistryExternalizeValidatesAndClonesBackendRef(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(time.Hour)
+	content := []byte("payload")
+	var request capsdk.ResourceExternalizeRequest
+	var backendRef = validRef(content, expires)
+	backend := &backendHarness{externalize: func(got capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		request = got
+		backendRef = refFromRequest("memory", "memory://objects/item", got)
+		return backendRef, nil
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	ref, err := registry.Externalize(context.Background(), "memory", bytes.NewReader(content), "application/json", "job-input", expires, trustedContext())
+	if err != nil {
+		t.Fatalf("Externalize() error = %v", err)
+	}
+	if string(request.Content) != string(content) || request.TrustedContext != trustedContext() || request.SizeBytes != 7 {
+		t.Fatalf("backend request = %#v", request)
+	}
+	backendRef.Uri = "memory://objects/mutated"
+	backendRef.Sha256[0] ^= 0xff
+	request.Content[0] = 'X'
+	if ref.GetUri() != "memory://objects/item" || string(content) != "payload" {
+		t.Fatalf("Externalize() returned aliased data: %#v content=%q", ref, content)
+	}
+}
+
+func TestResourceRegistryExternalizeBytes(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	backend := &backendHarness{}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	ref, err := registry.ExternalizeBytes(context.Background(), "memory", []byte("payload"), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if err != nil || ref.GetSizeBytes() != 7 {
+		t.Fatalf("ExternalizeBytes() ref=%v error=%v", ref, err)
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsUnknownWithoutFallback(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	called := false
+	backend := &backendHarness{externalize: func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		called = true
+		return nil, nil
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	_, err := registry.Externalize(context.Background(), "missing", strings.NewReader("payload"), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceExternalizerUnavailable) || called {
+		t.Fatalf("Externalize() error=%v called=%v", err, called)
+	}
+}
+
+func TestResourceRegistryExternalizeBoundsInput(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	reader := &countingReader{remaining: 1024}
+	called := false
+	backend := &backendHarness{externalize: func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		called = true
+		return nil, nil
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 4)
+	_, err := registry.Externalize(context.Background(), "memory", reader, "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceTooLarge) || called || reader.readBytes != 5 {
+		t.Fatalf("Externalize() error=%v called=%v bytes=%d", err, called, reader.readBytes)
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsUnsafeBackendReference(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	cases := map[string]func(*agentv1.ResourceRef){
+		"resolver": func(ref *agentv1.ResourceRef) { ref.ResolverId = "other" },
+		"digest":   func(ref *agentv1.ResourceRef) { ref.Sha256[0] ^= 0xff },
+		"type":     func(ref *agentv1.ResourceRef) { ref.MediaType = "text/plain" },
+		"size":     func(ref *agentv1.ResourceRef) { ref.SizeBytes++ },
+		"purpose":  func(ref *agentv1.ResourceRef) { ref.Purpose = "other" },
+		"expiry":   func(ref *agentv1.ResourceRef) { ref.ExpiresAt.Seconds++ },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			backend := &backendHarness{externalize: func(request capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+				ref := refFromRequest("memory", "memory://objects/item", request)
+				mutate(ref)
+				return ref, nil
+			}}
+			registry := newRegistry(t, fixedClock(now), backend, 64)
+			_, err := registry.Externalize(context.Background(), "memory", bytes.NewReader(content), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+			if !errors.Is(err, capsdk.ErrResourceMetadataMismatch) {
+				t.Fatalf("Externalize() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsCredentialURI(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	backend := &backendHarness{externalize: func(request capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		return refFromRequest("memory", "memory://user:secret@objects/item", request), nil
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	_, err := registry.Externalize(context.Background(), "memory", strings.NewReader("payload"), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, capsdk.ErrInvalidResourceRef) {
+		t.Fatalf("Externalize() error = %v", err)
+	}
+}
+
+func TestResourceRegistryExternalizeBoundsBackendErrors(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	secret := strings.Repeat("secret", 1000)
+	backend := &backendHarness{externalize: func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		return nil, errors.New(secret)
+	}}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	_, err := registry.Externalize(context.Background(), "memory", strings.NewReader("payload"), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceBackendUnavailable) || strings.Contains(err.Error(), secret) || len(err.Error()) > 100 {
+		t.Fatalf("Externalize() leaked backend error: %q", err)
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsCancellationAndExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	backend := &backendHarness{}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := registry.Externalize(ctx, "memory", strings.NewReader("payload"), "application/json", "job-input", now.Add(time.Hour), trustedContext())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Externalize() error = %v", err)
+	}
+	_, err = registry.Externalize(context.Background(), "memory", strings.NewReader("payload"), "application/json", "job-input", now, trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceExpired) {
+		t.Fatalf("expired Externalize() error = %v", err)
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsExpiryDuringBackendCall(t *testing.T) {
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	times := []time.Time{base, base.Add(2 * time.Second)}
+	index := 0
+	clock := func() time.Time { value := times[index]; index++; return value }
+	backend := &backendHarness{}
+	registry := newRegistry(t, clock, backend, 64)
+	_, err := registry.Externalize(
+		context.Background(), "memory", strings.NewReader("payload"),
+		"application/json", "job-input", base.Add(time.Second), trustedContext(),
+	)
+	if !errors.Is(err, capsdk.ErrResourceExpired) {
+		t.Fatalf("Externalize() error = %v", err)
+	}
+}

--- a/sdk/go/production_resource_registry_externalize_test.go
+++ b/sdk/go/production_resource_registry_externalize_test.go
@@ -162,18 +162,39 @@ func TestResourceRegistryExternalizeRejectsCancellationAtEndOfRead(t *testing.T)
 	}
 }
 
-func TestResourceRegistryExternalizeRejectsExpiryDuringBackendCall(t *testing.T) {
+func TestResourceRegistryExternalizeRejectsExpiryAfterReadBeforeBackend(t *testing.T) {
 	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	times := []time.Time{base, base.Add(2 * time.Second)}
 	index := 0
 	clock := func() time.Time { value := times[index]; index++; return value }
-	backend := &backendHarness{}
+	called := false
+	backend := &backendHarness{externalize: func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		called = true
+		return nil, nil
+	}}
 	registry := newRegistry(t, clock, backend, 64)
 	_, err := registry.Externalize(
 		context.Background(), "memory", strings.NewReader("payload"),
 		"application/json", "job-input", base.Add(time.Second), trustedContext(),
 	)
+	if !errors.Is(err, capsdk.ErrResourceExpired) || called {
+		t.Fatalf("Externalize() error=%v backend-called=%v", err, called)
+	}
+}
+
+func TestResourceRegistryExternalizeRejectsExpiryDuringBackendCall(t *testing.T) {
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	times := []time.Time{base, base, base.Add(2 * time.Second)}
+	index := 0
+	clock := func() time.Time { value := times[index]; index++; return value }
+	backend := &backendHarness{}
+	registry := newRegistry(t, clock, backend, 64)
+
+	_, err := registry.Externalize(
+		context.Background(), "memory", strings.NewReader("payload"),
+		"application/json", "job-input", base.Add(time.Second), trustedContext(),
+	)
 	if !errors.Is(err, capsdk.ErrResourceExpired) {
-		t.Fatalf("Externalize() error = %v", err)
+		t.Fatalf("Externalize() error=%v", err)
 	}
 }

--- a/sdk/go/production_resource_registry_resolve_test.go
+++ b/sdk/go/production_resource_registry_resolve_test.go
@@ -80,8 +80,13 @@ func TestResourceRegistryResolveUsesTrustedContextAndClonesBytes(t *testing.T) {
 		t.Fatalf("backend request = %#v", got)
 	}
 	backendContent[0] = 'X'
-	if string(resolved.Content) != string(content) || resolved.MediaType != "application/json" {
+	resolvedContent := resolved.Content()
+	if string(resolvedContent) != string(content) || resolved.MediaType() != "application/json" {
 		t.Fatalf("Resolve() = %#v", resolved)
+	}
+	resolvedContent[0] = 'X'
+	if string(resolved.Content()) != string(content) {
+		t.Fatalf("Content() returned an alias: %q", resolved.Content())
 	}
 }
 

--- a/sdk/go/production_resource_registry_resolve_test.go
+++ b/sdk/go/production_resource_registry_resolve_test.go
@@ -1,0 +1,257 @@
+package capsdk_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	capsdk "github.com/cordum-io/cap/v2/sdk/go"
+)
+
+func TestNewResourceRegistryRejectsUnsafeRegistrations(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	backend := &backendHarness{}
+	valid := capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: backend.resolver(), Externalizer: backend.externalizer(),
+	}
+	cases := map[string][]capsdk.ResourceBackendRegistration{
+		"empty":                  nil,
+		"nil resolver":           {{ID: "memory", MaxBytes: 64, Externalizer: backend.externalizer()}},
+		"typed nil resolver":     {{ID: "memory", MaxBytes: 64, Resolver: resolverFunc(nil), Externalizer: backend.externalizer()}},
+		"nil writer":             {{ID: "memory", MaxBytes: 64, Resolver: backend.resolver()}},
+		"typed nil externalizer": {{ID: "memory", MaxBytes: 64, Resolver: backend.resolver(), Externalizer: externalizerFunc(nil)}},
+		"invalid id":             {{ID: "Memory", MaxBytes: 64, Resolver: backend.resolver(), Externalizer: backend.externalizer()}},
+		"zero bound":             {{ID: "memory", Resolver: backend.resolver(), Externalizer: backend.externalizer()}},
+		"global bound":           {{ID: "memory", MaxBytes: capsdk.MaxResourceSizeBytes + 1, Resolver: backend.resolver(), Externalizer: backend.externalizer()}},
+		"duplicate id":           {valid, valid},
+	}
+	for name, registrations := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := capsdk.NewResourceRegistry(fixedClock(now), registrations...)
+			if !errors.Is(err, capsdk.ErrInvalidResourceRegistry) {
+				t.Fatalf("NewResourceRegistry() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewResourceRegistrySnapshotsRegistrations(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	backend := &backendHarness{content: content, mediaType: "application/json"}
+	registrations := []capsdk.ResourceBackendRegistration{{
+		ID: "memory", MaxBytes: 64, Resolver: backend.resolver(), Externalizer: backend.externalizer(),
+	}}
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), registrations...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registrations[0] = capsdk.ResourceBackendRegistration{ID: "changed"}
+	if _, err := registry.Resolve(context.Background(), validRef(content, now.Add(time.Hour)), trustedContext()); err != nil {
+		t.Fatalf("Resolve() after caller mutation error = %v", err)
+	}
+}
+
+func TestResourceRegistryResolveUsesTrustedContextAndClonesBytes(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte(`{"ok":true}`)
+	backendContent := append([]byte(nil), content...)
+	var got capsdk.ResourceResolveRequest
+	backend := &backendHarness{content: backendContent, mediaType: "application/json"}
+	backendResolver := resolverFunc(func(_ context.Context, request capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		got = request
+		return capsdk.ResourceResolveResult{Body: io.NopCloser(bytes.NewReader(backendContent)), MediaType: "application/json"}, nil
+	})
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: backendResolver, Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := registry.Resolve(context.Background(), validRef(content, now.Add(time.Hour)), trustedContext())
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.TrustedContext != trustedContext() || got.URI != "memory://objects/item" {
+		t.Fatalf("backend request = %#v", got)
+	}
+	backendContent[0] = 'X'
+	if string(resolved.Content) != string(content) || resolved.MediaType != "application/json" {
+		t.Fatalf("Resolve() = %#v", resolved)
+	}
+}
+
+func TestResourceRegistryResolveRejectsUnknownWithoutFallback(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	backend := &backendHarness{content: content, mediaType: "application/octet-stream"}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	ref := validRef(content, now.Add(time.Hour))
+	ref.ResolverId = "missing"
+	ref.Uri = "memory://objects/item"
+	ref.MediaType = "application/octet-stream"
+	_, err := registry.Resolve(context.Background(), ref, trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceResolverUnavailable) {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if backend.resolveCalls != 0 {
+		t.Fatalf("registered fallback called %d times", backend.resolveCalls)
+	}
+}
+
+func TestResourceRegistryResolveRejectsBeforeBackend(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	backend := &backendHarness{content: []byte("x"), mediaType: "application/json"}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	ref := validRef([]byte("x"), now.Add(time.Hour))
+	if _, err := registry.Resolve(cancelled, ref, trustedContext()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Resolve() error = %v", err)
+	}
+	ref.Sha256 = []byte("short")
+	if _, err := registry.Resolve(context.Background(), ref, trustedContext()); !errors.Is(err, capsdk.ErrInvalidResourceRef) {
+		t.Fatalf("invalid Resolve() error = %v", err)
+	}
+	if backend.resolveCalls != 0 {
+		t.Fatalf("backend called %d times", backend.resolveCalls)
+	}
+}
+
+func TestResourceRegistryResolveRejectsCancellationAtEndOfRead(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	ctx, cancel := context.WithCancel(context.Background())
+	resolver := resolverFunc(func(context.Context, capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		body := &cancelOnReadCloser{Reader: bytes.NewReader(content), cancel: cancel}
+		return capsdk.ResourceResolveResult{Body: body, MediaType: "application/json"}, nil
+	})
+	backend := &backendHarness{}
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: resolver, Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = registry.Resolve(ctx, validRef(content, now.Add(time.Hour)), trustedContext())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+}
+
+func TestResourceRegistryResolveRejectsExpiryBeforeAndAfterFetch(t *testing.T) {
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	backend := &backendHarness{content: content, mediaType: "application/json"}
+	expiredRegistry := newRegistry(t, fixedClock(base), backend, 64)
+	if _, err := expiredRegistry.Resolve(context.Background(), validRef(content, base), trustedContext()); !errors.Is(err, capsdk.ErrResourceExpired) {
+		t.Fatalf("pre-fetch expiry error = %v", err)
+	}
+	times := []time.Time{base, base.Add(2 * time.Second)}
+	index := 0
+	raceClock := func() time.Time { value := times[index]; index++; return value }
+	raceRegistry := newRegistry(t, raceClock, backend, 64)
+	if _, err := raceRegistry.Resolve(context.Background(), validRef(content, base.Add(time.Second)), trustedContext()); !errors.Is(err, capsdk.ErrResourceExpired) {
+		t.Fatalf("post-fetch expiry error = %v", err)
+	}
+}
+
+func TestResourceRegistryResolveRejectsContentMismatches(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	want := []byte("payload")
+	cases := map[string]struct {
+		content []byte
+		media   string
+		err     error
+	}{
+		"short":  {[]byte("pay"), "application/json", capsdk.ErrResourceSizeMismatch},
+		"digest": {[]byte("PAYLOAD"), "application/json", capsdk.ErrResourceDigestMismatch},
+		"type":   {want, "text/plain", capsdk.ErrResourceMediaTypeMismatch},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			backend := &backendHarness{content: tc.content, mediaType: tc.media}
+			registry := newRegistry(t, fixedClock(now), backend, 64)
+			_, err := registry.Resolve(context.Background(), validRef(want, now.Add(time.Hour)), trustedContext())
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestResourceRegistryResolveBoundsOversizeRead(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	reader := &countingReader{remaining: 1024}
+	resolver := resolverFunc(func(context.Context, capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		return capsdk.ResourceResolveResult{Body: io.NopCloser(reader), MediaType: "application/json"}, nil
+	})
+	backend := &backendHarness{}
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: resolver, Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = registry.Resolve(context.Background(), validRef([]byte("1234"), now.Add(time.Hour)), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceTooLarge) || reader.readBytes != 5 {
+		t.Fatalf("Resolve() error = %v, bytes read = %d", err, reader.readBytes)
+	}
+}
+
+func TestResourceRegistryResolveBoundsBackendErrors(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	secret := strings.Repeat("secret", 1000)
+	resolver := resolverFunc(func(context.Context, capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		return capsdk.ResourceResolveResult{}, errors.New(secret)
+	})
+	backend := &backendHarness{}
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: resolver, Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = registry.Resolve(context.Background(), validRef([]byte("x"), now.Add(time.Hour)), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceBackendUnavailable) || strings.Contains(err.Error(), secret) || len(err.Error()) > 100 {
+		t.Fatalf("Resolve() leaked backend error: %q", err)
+	}
+}
+
+type countingReader struct {
+	remaining int
+	readBytes int
+}
+
+type cancelOnReadCloser struct {
+	*bytes.Reader
+	cancel context.CancelFunc
+}
+
+func (reader *cancelOnReadCloser) Read(buffer []byte) (int, error) {
+	count, _ := reader.Reader.Read(buffer)
+	reader.cancel()
+	return count, io.EOF
+}
+
+func (*cancelOnReadCloser) Close() error { return nil }
+
+func (reader *countingReader) Read(buffer []byte) (int, error) {
+	if reader.remaining == 0 {
+		return 0, io.EOF
+	}
+	count := len(buffer)
+	if count > reader.remaining {
+		count = reader.remaining
+	}
+	for index := 0; index < count; index++ {
+		buffer[index] = 'x'
+	}
+	reader.remaining -= count
+	reader.readBytes += count
+	return count, nil
+}

--- a/sdk/go/production_resource_registry_security_test.go
+++ b/sdk/go/production_resource_registry_security_test.go
@@ -34,6 +34,30 @@ func TestResourceRegistryRejectsInvalidTrustedContextBeforeBackend(t *testing.T)
 	}
 }
 
+func TestResourceRegistryRejectsMissingOperationContext(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	backend := &backendHarness{content: content, mediaType: "application/json"}
+	externalizeCalls := 0
+	backend.externalize = func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+		externalizeCalls++
+		return nil, nil
+	}
+	registry := newRegistry(t, fixedClock(now), backend, 64)
+
+	_, resolveErr := registry.Resolve(nil, validRef(content, now.Add(time.Hour)), trustedContext())
+	_, externalizeErr := registry.ExternalizeBytes(
+		nil, "memory", content, "application/json", "job-input", now.Add(time.Hour), trustedContext(),
+	)
+	if !errors.Is(resolveErr, capsdk.ErrResourceContextRequired) ||
+		!errors.Is(externalizeErr, capsdk.ErrResourceContextRequired) {
+		t.Fatalf("Resolve error=%v Externalize error=%v", resolveErr, externalizeErr)
+	}
+	if backend.resolveCalls != 0 || externalizeCalls != 0 {
+		t.Fatalf("backend calls resolve=%d externalize=%d", backend.resolveCalls, externalizeCalls)
+	}
+}
+
 func invalidTrustedResourceContexts() map[string]capsdk.TrustedResourceContext {
 	return map[string]capsdk.TrustedResourceContext{
 		"empty tenant":   {JobID: "job-7"},

--- a/sdk/go/production_resource_registry_security_test.go
+++ b/sdk/go/production_resource_registry_security_test.go
@@ -1,0 +1,106 @@
+package capsdk_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+	capsdk "github.com/cordum-io/cap/v2/sdk/go"
+)
+
+func TestResourceRegistryRejectsInvalidTrustedContextBeforeBackend(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	content := []byte("payload")
+	cases := invalidTrustedResourceContexts()
+	for name, trusted := range cases {
+		t.Run(name, func(t *testing.T) {
+			externalizeCalls := 0
+			backend := &backendHarness{content: content, mediaType: "application/json"}
+			backend.externalize = func(capsdk.ResourceExternalizeRequest) (*agentv1.ResourceRef, error) {
+				externalizeCalls++
+				return nil, nil
+			}
+			registry := newRegistry(t, fixedClock(now), backend, 64)
+			_, resolveErr := registry.Resolve(context.Background(), validRef(content, now.Add(time.Hour)), trusted)
+			_, externalizeErr := registry.ExternalizeBytes(
+				context.Background(), "memory", content, "application/json", "job-input", now.Add(time.Hour), trusted,
+			)
+			assertTrustedContextRejected(t, resolveErr, externalizeErr, backend.resolveCalls, externalizeCalls)
+		})
+	}
+}
+
+func invalidTrustedResourceContexts() map[string]capsdk.TrustedResourceContext {
+	return map[string]capsdk.TrustedResourceContext{
+		"empty tenant":   {JobID: "job-7"},
+		"empty job":      {TenantID: "tenant-a"},
+		"invalid tenant": {TenantID: "tenant/a", JobID: "job-7"},
+		"invalid job":    {TenantID: "tenant-a", JobID: "job 7"},
+		"tenant too long": {
+			TenantID: strings.Repeat("t", capsdk.MaxTrustedTenantIDBytes+1), JobID: "job-7",
+		},
+		"job too long": {
+			TenantID: "tenant-a", JobID: strings.Repeat("j", capsdk.MaxTrustedJobIDBytes+1),
+		},
+	}
+}
+
+func assertTrustedContextRejected(t *testing.T, resolveErr, externalizeErr error, resolveCalls, externalizeCalls int) {
+	t.Helper()
+	if !errors.Is(resolveErr, capsdk.ErrInvalidTrustedResourceContext) ||
+		!errors.Is(externalizeErr, capsdk.ErrInvalidTrustedResourceContext) {
+		t.Fatalf("Resolve error=%v Externalize error=%v", resolveErr, externalizeErr)
+	}
+	if resolveCalls != 0 || externalizeCalls != 0 {
+		t.Fatalf("backend calls resolve=%d externalize=%d", resolveCalls, externalizeCalls)
+	}
+}
+
+func TestResourceRegistryResolveClosesBodyReturnedWithError(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	body := &closeCountingReader{Reader: strings.NewReader("payload")}
+	registry := newErroringResolverRegistry(t, now, body)
+	_, err := registry.Resolve(context.Background(), validRef([]byte("payload"), now.Add(time.Hour)), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceBackendUnavailable) || body.closeCalls != 1 {
+		t.Fatalf("Resolve() error=%v close-calls=%d", err, body.closeCalls)
+	}
+}
+
+func TestResourceRegistryResolveIgnoresTypedNilBodyReturnedWithError(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	var body *closeCountingReader
+	registry := newErroringResolverRegistry(t, now, body)
+	_, err := registry.Resolve(context.Background(), validRef([]byte("payload"), now.Add(time.Hour)), trustedContext())
+	if !errors.Is(err, capsdk.ErrResourceBackendUnavailable) {
+		t.Fatalf("Resolve() error=%v", err)
+	}
+}
+
+func newErroringResolverRegistry(t *testing.T, now time.Time, body io.ReadCloser) *capsdk.ResourceRegistry {
+	t.Helper()
+	resolver := resolverFunc(func(context.Context, capsdk.ResourceResolveRequest) (capsdk.ResourceResolveResult, error) {
+		return capsdk.ResourceResolveResult{Body: body}, errors.New("backend secret")
+	})
+	backend := &backendHarness{}
+	registry, err := capsdk.NewResourceRegistry(fixedClock(now), capsdk.ResourceBackendRegistration{
+		ID: "memory", MaxBytes: 64, Resolver: resolver, Externalizer: backend.externalizer(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registry
+}
+
+type closeCountingReader struct {
+	io.Reader
+	closeCalls int
+}
+
+func (reader *closeCountingReader) Close() error {
+	reader.closeCalls++
+	return nil
+}

--- a/sdk/go/production_resource_resolve.go
+++ b/sdk/go/production_resource_resolve.go
@@ -38,6 +38,7 @@ func (registry *ResourceRegistry) Resolve(
 	}
 	result, err := backend.resolver.Resolve(ctx, resolveRequest(snapshot, trusted))
 	if err != nil {
+		closeResourceBody(result.Body)
 		return ResolvedResource{}, collapseBackendError(ctx)
 	}
 	content, err := readAndCloseBounded(ctx, result.Body, snapshot.GetSizeBytes())
@@ -53,7 +54,7 @@ func (registry *ResourceRegistry) Resolve(
 	if err := verifyResolvedContent(snapshot, result.MediaType, content); err != nil {
 		return ResolvedResource{}, err
 	}
-	return ResolvedResource{Content: append([]byte(nil), content...), MediaType: result.MediaType}, nil
+	return newResolvedResource(content, result.MediaType), nil
 }
 
 func (registry *ResourceRegistry) resolveSnapshot(
@@ -133,6 +134,9 @@ func readBounded(ctx context.Context, reader io.Reader, limit uint64) ([]byte, e
 			chunk = chunk[:remaining]
 		}
 		count, err := reader.Read(chunk)
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
 		if count < 0 || count > len(chunk) {
 			return nil, ErrResourceBackendUnavailable
 		}
@@ -171,6 +175,12 @@ func collapseBackendError(ctx context.Context) error {
 		return err
 	}
 	return ErrResourceBackendUnavailable
+}
+
+func closeResourceBody(body io.ReadCloser) {
+	if !readCloserIsNil(body) {
+		_ = body.Close()
+	}
 }
 
 func readerIsNil(reader io.Reader) bool {

--- a/sdk/go/production_resource_resolve.go
+++ b/sdk/go/production_resource_resolve.go
@@ -24,7 +24,7 @@ func (registry *ResourceRegistry) Resolve(
 		return ResolvedResource{}, ErrInvalidResourceRegistry
 	}
 	if ctx == nil {
-		return ResolvedResource{}, ErrInvalidTrustedResourceContext
+		return ResolvedResource{}, ErrResourceContextRequired
 	}
 	if err := ctx.Err(); err != nil {
 		return ResolvedResource{}, err

--- a/sdk/go/production_resource_resolve.go
+++ b/sdk/go/production_resource_resolve.go
@@ -1,0 +1,188 @@
+package capsdk
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"io"
+	"reflect"
+	"time"
+
+	agentv1 "github.com/cordum-io/cap/v2/cordum/agent/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// Resolve fetches through the exact installed resolver selected by ref, then
+// rechecks expiry and verifies the declared media type, size, and SHA-256.
+func (registry *ResourceRegistry) Resolve(
+	ctx context.Context,
+	ref *agentv1.ResourceRef,
+	trusted TrustedResourceContext,
+) (ResolvedResource, error) {
+	if !registry.valid() {
+		return ResolvedResource{}, ErrInvalidResourceRegistry
+	}
+	if ctx == nil {
+		return ResolvedResource{}, ErrInvalidTrustedResourceContext
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedResource{}, err
+	}
+	if err := validateTrustedResourceContext(trusted); err != nil {
+		return ResolvedResource{}, err
+	}
+	snapshot, backend, expiresAt, err := registry.resolveSnapshot(ref)
+	if err != nil {
+		return ResolvedResource{}, err
+	}
+	result, err := backend.resolver.Resolve(ctx, resolveRequest(snapshot, trusted))
+	if err != nil {
+		return ResolvedResource{}, collapseBackendError(ctx)
+	}
+	content, err := readAndCloseBounded(ctx, result.Body, snapshot.GetSizeBytes())
+	if err != nil {
+		return ResolvedResource{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedResource{}, err
+	}
+	if !expiresAt.After(registry.currentTime()) {
+		return ResolvedResource{}, ErrResourceExpired
+	}
+	if err := verifyResolvedContent(snapshot, result.MediaType, content); err != nil {
+		return ResolvedResource{}, err
+	}
+	return ResolvedResource{Content: append([]byte(nil), content...), MediaType: result.MediaType}, nil
+}
+
+func (registry *ResourceRegistry) resolveSnapshot(
+	ref *agentv1.ResourceRef,
+) (*agentv1.ResourceRef, resourceBackend, time.Time, error) {
+	if ref == nil {
+		return nil, resourceBackend{}, time.Time{}, ErrInvalidResourceRef
+	}
+	snapshot := proto.Clone(ref).(*agentv1.ResourceRef)
+	now := registry.currentTime()
+	if err := validateGenericResourceRef(snapshot, now); err != nil {
+		return nil, resourceBackend{}, time.Time{}, err
+	}
+	backend, installed := registry.backends[snapshot.GetResolverId()]
+	if !installed {
+		return nil, resourceBackend{}, time.Time{}, ErrResourceResolverUnavailable
+	}
+	if snapshot.GetSizeBytes() > backend.maxBytes {
+		return nil, resourceBackend{}, time.Time{}, ErrResourceTooLarge
+	}
+	return snapshot, backend, snapshot.GetExpiresAt().AsTime(), nil
+}
+
+func validateGenericResourceRef(ref *agentv1.ResourceRef, now time.Time) error {
+	installed := []string{ref.GetResolverId()}
+	if err := ValidateResourceRefAt(ref, installed, now); err != nil {
+		if resourceRefExpiredAt(ref, now) {
+			return ErrResourceExpired
+		}
+		return err
+	}
+	return nil
+}
+
+func resourceRefExpiredAt(ref *agentv1.ResourceRef, now time.Time) bool {
+	if ref == nil || ref.GetExpiresAt() == nil || ref.GetExpiresAt().CheckValid() != nil {
+		return false
+	}
+	return !ref.GetExpiresAt().AsTime().After(now)
+}
+
+func resolveRequest(ref *agentv1.ResourceRef, trusted TrustedResourceContext) ResourceResolveRequest {
+	return ResourceResolveRequest{
+		TrustedContext: trusted, URI: ref.GetUri(), MediaType: ref.GetMediaType(),
+		Purpose: ref.GetPurpose(), DeclaredSizeBytes: ref.GetSizeBytes(),
+	}
+}
+
+func readAndCloseBounded(ctx context.Context, body io.ReadCloser, limit uint64) ([]byte, error) {
+	if readCloserIsNil(body) {
+		return nil, ErrResourceBackendUnavailable
+	}
+	content, readErr := readBounded(ctx, body, limit)
+	closeErr := body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, ErrResourceBackendUnavailable
+	}
+	return content, nil
+}
+
+func readBounded(ctx context.Context, reader io.Reader, limit uint64) ([]byte, error) {
+	if readerIsNil(reader) || limit == 0 {
+		return nil, ErrResourceBackendUnavailable
+	}
+	var output bytes.Buffer
+	buffer := make([]byte, 32*1024)
+	for uint64(output.Len()) <= limit {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		remaining := limit + 1 - uint64(output.Len())
+		chunk := buffer
+		if uint64(len(chunk)) > remaining {
+			chunk = chunk[:remaining]
+		}
+		count, err := reader.Read(chunk)
+		if count < 0 || count > len(chunk) {
+			return nil, ErrResourceBackendUnavailable
+		}
+		if count > 0 {
+			_, _ = output.Write(chunk[:count])
+			if uint64(output.Len()) > limit {
+				return nil, ErrResourceTooLarge
+			}
+		}
+		if err == io.EOF {
+			return output.Bytes(), nil
+		}
+		if err != nil || count == 0 {
+			return nil, ErrResourceBackendUnavailable
+		}
+	}
+	return nil, ErrResourceTooLarge
+}
+
+func verifyResolvedContent(ref *agentv1.ResourceRef, mediaType string, content []byte) error {
+	if mediaType != ref.GetMediaType() {
+		return ErrResourceMediaTypeMismatch
+	}
+	if uint64(len(content)) != ref.GetSizeBytes() {
+		return ErrResourceSizeMismatch
+	}
+	digest := sha256.Sum256(content)
+	if subtle.ConstantTimeCompare(digest[:], ref.GetSha256()) != 1 {
+		return ErrResourceDigestMismatch
+	}
+	return nil
+}
+
+func collapseBackendError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return ErrResourceBackendUnavailable
+}
+
+func readerIsNil(reader io.Reader) bool {
+	if reader == nil {
+		return true
+	}
+	return nilReflectValue(reflect.ValueOf(reader))
+}
+
+func readCloserIsNil(reader io.ReadCloser) bool {
+	if reader == nil {
+		return true
+	}
+	return nilReflectValue(reflect.ValueOf(reader))
+}


### PR DESCRIPTION
Unblocks the retained prerequisite gate for the Adoption and Interop tasks by landing the already-reviewed standalone CAP Go ResourceRef registry.

## Scope
- sealed operator-installed resolver/externalizer registries
- verified Resolve path with tenant/job authority, digest, media-type, size, and expiry checks
- bounded Externalize path with the same authority/integrity contract
- opaque clone-safe `ResolvedResource`
- cancellation and backend-error cleanup hardening
- no generic network/file fallback and no embedded credentials
- external-package API/negative tests

This is a clean replay of the signed support commits `7c707f3` and `1ffe192` onto current CAP main `0ea8574`; no new wire fields or generated artifacts.

## Fresh verification
- `go test ./sdk/go -run 'ResourceRegistry|ResolvedResource' -count=3`
- `go test ./sdk/go/... -count=1`
- `go vet ./sdk/go/...`
- committed Go blobs are gofmt-clean
- `git diff --check origin/main..HEAD`

All passed locally on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resource registry for configuring resolver and externalizer backends.
  * Added resource resolution with integrity, size, media type, expiration, and cancellation checks.
  * Added resource externalization from readers or byte slices.
  * Added trusted context validation and standardized resource error handling.
  * Added opaque resolved-resource accessors that protect verified content.

* **Tests**
  * Added comprehensive coverage for validation, security, cancellation, expiration, backend failures, cloning, and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->