### PR TITLE
release: promote CAP v2.17.0 to published release

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,10 @@ flowchart LR
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current verified published release:** 2.16.1 (tag `v2.16.1`, 2026-07-22, channel stable)
+- **Current verified published release:** 2.17.0 (tag `v2.17.0`, 2026-07-22, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents
-- **Prepared release snapshot:** 2.17.0 (tag `v2.17.0`, channel stable); publication status is not asserted by this source state.
 <!-- cap-release:end -->
 
 ## Learn More

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 <!-- cap-release:begin:security-lines -->
 | Version | Supported |
 | --- | --- |
-| 2.16.x | :white_check_mark: |
+| 2.17.x | :white_check_mark: |
 <!-- cap-release:end -->
 
 ## Reporting a Vulnerability

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,11 +5,10 @@ Deep technical content for implementers. For an overview, see the [README](../RE
 ## Status
 
 <!-- cap-release:begin:release-status -->
-- **Current verified published release:** 2.16.1 (tag `v2.16.1`, 2026-07-22, channel stable)
+- **Current verified published release:** 2.17.0 (tag `v2.17.0`, 2026-07-22, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents
-- **Prepared release snapshot:** 2.17.0 (tag `v2.17.0`, channel stable); publication status is not asserted by this source state.
 <!-- cap-release:end -->
 
 - Reference implementation: Cordum.

--- a/docs/sdk-comparison.md
+++ b/docs/sdk-comparison.md
@@ -7,10 +7,10 @@ CAP ships three protocol SDKs (Go, Node, Python) that speak directly to the NATS
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.16.1 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.16.1 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.16.1 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.16.1 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.17.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.17.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.17.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.17.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |

--- a/internal/releasetruth/golden_test.go
+++ b/internal/releasetruth/golden_test.go
@@ -35,8 +35,8 @@ func TestGoldenManifest_IsValidAndOnDisk(t *testing.T) {
 	if ps := CheckSpecsOnDisk(m, root); len(ps) != 0 {
 		t.Fatalf("golden manifest specs missing on disk: %v", ps)
 	}
-	if m.Release.Version != "2.16.1" {
-		t.Errorf("golden release version = %q, want 2.16.1", m.Release.Version)
+	if m.Release.Version != "2.17.0" {
+		t.Errorf("golden release version = %q, want 2.17.0", m.Release.Version)
 	}
 	if m.Wire.ProtocolVersion != 1 {
 		t.Errorf("golden wire protocol = %d, want 1", m.Wire.ProtocolVersion)
@@ -45,7 +45,7 @@ func TestGoldenManifest_IsValidAndOnDisk(t *testing.T) {
 
 // TestGoldenManifest_GuardTracksReleaseVersion pins the released cordum-guard
 // artifact to the release train. The PyPI cordum-guard package publishes on the
-// same version line as the SDKs (latest 2.16.1); source pyproject carries an
+// same version line as the SDKs (latest 2.17.0); source pyproject carries an
 // in-development version that must not masquerade as the published artifact.
 func TestGoldenManifest_GuardTracksReleaseVersion(t *testing.T) {
 	m, _ := loadGolden(t)

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -2,20 +2,15 @@
   "$schema": "./manifest.schema.json",
   "schemaVersion": "1.2.0",
   "release": {
-    "version": "2.16.1",
-    "tag": "v2.16.1",
-    "date": "2026-07-22",
-    "commit": "32b9db9670c597685344808272f9b246026091ba",
-    "channel": "stable"
-  },
-  "snapshot": {
     "version": "2.17.0",
     "tag": "v2.17.0",
+    "date": "2026-07-22",
+    "commit": "e580c670d54a7563c749835c7dd09d81f116c823",
     "channel": "stable"
   },
   "development": {
-    "commit": "3ca24af",
-    "describe": "v2.16.1-9-g3ca24af",
+    "commit": "e580c67",
+    "describe": "v2.17.0",
     "released": false
   },
   "wire": {
@@ -55,7 +50,7 @@
       "package": "github.com/cordum-io/cap/v2",
       "registry": "proxy.golang.org",
       "import": "github.com/cordum-io/cap/v2/sdk/go",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "toolchain": "go1.25.12",
       "publication": "published",
       "evidence": "sdk/go conformance_test.go plus CI real-NATS end-to-end and immutable-tag publication verification"
@@ -68,7 +63,7 @@
       "package": "cap-sdk-node",
       "registry": "registry.npmjs.org",
       "import": "cap-sdk-node",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "toolchain": "node20",
       "publication": "published",
       "evidence": "CI build, source tests, package verification, and immutable-tag npm publication verification"
@@ -81,7 +76,7 @@
       "package": "cap-sdk-python",
       "registry": "pypi.org",
       "import": "cap-sdk-python",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "toolchain": "python3.11",
       "publication": "published",
       "evidence": "CI pytest, clean wheel and sdist verification, and immutable-tag PyPI publication verification"
@@ -94,7 +89,7 @@
       "package": "cordum-guard",
       "registry": "pypi.org",
       "import": "cordum-guard",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "toolchain": "python3.11",
       "publication": "published",
       "evidence": "unit tests plus immutable-tag PyPI publication verification for the manifest-declared release"
@@ -123,7 +118,7 @@
     "python": { "tested": "3.11", "minimum": "3.9" }
   },
   "security": {
-    "supportedLines": ["2.16.x"],
+    "supportedLines": ["2.17.x"],
     "reportingRoute": "SECURITY.md"
   },
   "links": [

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -7,10 +7,10 @@ This folder contains SDKs for CAP.
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.16.1 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.16.1 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.16.1 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.16.1 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.17.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.17.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.17.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.17.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cap-sdk-node",
-  "version": "2.17.0",
+  "version": "2.17.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cap-sdk-node",
-      "version": "2.17.0",
+      "version": "2.17.1-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "nats": "^2.16.0",

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cap-sdk-node",
-  "version": "2.17.1-dev",
+  "version": "2.17.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cap-sdk-node",
-      "version": "2.17.1-dev",
+      "version": "2.17.1-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "nats": "^2.16.0",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cap-sdk-node",
-  "version": "2.17.0",
+  "version": "2.17.1-dev",
   "description": "CAP (Cordum Agent Protocol) SDK for Node/TypeScript",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cap-sdk-node",
-  "version": "2.17.1-dev",
+  "version": "2.17.1-dev.0",
   "description": "CAP (Cordum Agent Protocol) SDK for Node/TypeScript",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/sdk/python-guard/pyproject.toml
+++ b/sdk/python-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordum-guard"
-version = "2.17.1-dev"
+version = "2.17.1.dev0"
 description = "Cordum Safety Guard — @guard decorator for LangChain, LlamaIndex, and plain Python functions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python-guard/pyproject.toml
+++ b/sdk/python-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordum-guard"
-version = "2.17.0"
+version = "2.17.1-dev"
 description = "Cordum Safety Guard — @guard decorator for LangChain, LlamaIndex, and plain Python functions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cap-sdk-python"
-version = "2.17.0"
+version = "2.17.1-dev"
 description = "CAP (Cordum Agent Protocol) Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cap-sdk-python"
-version = "2.17.1-dev"
+version = "2.17.1.dev0"
 description = "CAP (Cordum Agent Protocol) Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/spec/00-index.md
+++ b/spec/00-index.md
@@ -18,11 +18,10 @@ Tags: `conformance`, `fixtures`, `testing`, `signing`, `deterministic`.
 - Repository/SDK releases track implementation and are pinned by tag for reproducibility.
 
 <!-- cap-release:begin:release-status -->
-- **Current verified published release:** 2.16.1 (tag `v2.16.1`, 2026-07-22, channel stable)
+- **Current verified published release:** 2.17.0 (tag `v2.17.0`, 2026-07-22, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents
-- **Prepared release snapshot:** 2.17.0 (tag `v2.17.0`, channel stable); publication status is not asserted by this source state.
 <!-- cap-release:end -->
 
 - For the full versioning policy, see [17 Versioning Policy](17-versioning-policy.md).

--- a/spec/17-versioning-policy.md
+++ b/spec/17-versioning-policy.md
@@ -16,9 +16,8 @@ The `protocol_version` field in `BusPacket` carries the wire version as a positi
 
 <!-- cap-release:begin:version-policy -->
 - **Wire protocol version:** 1. Wire evolution is append-only within the compatible range 1–1.
-- **Current published release:** 2.16.1 (tag `v2.16.1`). SDK and repository releases track implementation and are pinned by tag.
+- **Current published release:** 2.17.0 (tag `v2.17.0`). SDK and repository releases track implementation and are pinned by tag.
 - **Source versus release:** development source may carry an in-progress version distinct from the latest published artifact; the release manifest is the authority on what is published.
-- **Prepared release snapshot:** 2.17.0 (tag `v2.17.0`, channel stable); publication status is not asserted by this source state.
 <!-- cap-release:end -->
 
 ### What constitutes a breaking wire change

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -17,11 +17,10 @@ This wiki provides a comprehensive guide to understanding, using, and contributi
 ## Release Status
 
 <!-- cap-release:begin:release-status -->
-- **Current verified published release:** 2.16.1 (tag `v2.16.1`, 2026-07-22, channel stable)
+- **Current verified published release:** 2.17.0 (tag `v2.17.0`, 2026-07-22, channel stable)
 - **Wire protocol:** 1 (compatible range 1–1)
 - **Wire schema:** 1.0.0
 - **Specifications:** 20 normative documents
-- **Prepared release snapshot:** 2.17.0 (tag `v2.17.0`, channel stable); publication status is not asserted by this source state.
 <!-- cap-release:end -->
 
 ## SDK Support
@@ -29,10 +28,10 @@ This wiki provides a comprehensive guide to understanding, using, and contributi
 <!-- cap-release:begin:sdk-table -->
 | Component | Language | Kind | Tier | Registry | Package | Version | Toolchain |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.16.1 | go1.25.12 |
-| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.16.1 | node20 |
-| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.16.1 | python3.11 |
-| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.16.1 | python3.11 |
+| cap-go | go | sdk | stable | proxy.golang.org | github.com/cordum-io/cap/v2 | 2.17.0 | go1.25.12 |
+| cap-node | node | sdk | stable | registry.npmjs.org | cap-sdk-node | 2.17.0 | node20 |
+| cap-python | python | sdk | stable | pypi.org | cap-sdk-python | 2.17.0 | python3.11 |
+| cordum-guard | python | extension | stable | pypi.org | cordum-guard | 2.17.0 | python3.11 |
 | cap-cpp | cpp | sdk | experimental | - | - | - | - |
 | cap-dotnet | dotnet | sdk | experimental | - | - | - | - |
 | cap-java | java | sdk | experimental | - | - | - | - |


### PR DESCRIPTION
Post-publication manifest promotion for v2.17.0, mirroring the v2.16.1 promotion (b48183a) exactly.

## What
- `release/manifest.json`: release block -> 2.17.0 / v2.17.0 / 2026-07-22 / `e580c670d54a7563c749835c7dd09d81f116c823`; snapshot block folded in; development block -> `e580c67`/`v2.17.0`; four stable components -> 2.17.0 published; security supportedLines -> `2.17.x`.
- Source metadata bumped past the published version (2.17.1-dev in sdk/node package.json+lock, sdk/python and sdk/python-guard pyprojects) per CheckSourceMetadata's development-marker requirement.
- `internal/releasetruth/golden_test.go` hardcoded expectation 2.16.1 -> 2.17.0.
- Rendered docs regenerated via `cap-release render --write` (README, SECURITY, docs/reference, docs/sdk-comparison, sdk/README, spec/00-index, spec/17-versioning-policy, wiki/Home).

## Registry verification (independent, live)
- GitHub Release v2.17.0 published 2026-07-22T20:01:47Z; all four publish workflows completed/success.
- proxy.golang.org: v2.17.0 Origin.Hash `e580c670d54a7563c749835c7dd09d81f116c823`; Sum `h1:55v0RkLUClCGKTJWknZPj731xKuqhiHe4pzXox4zMno=`.
- registry.npmjs.org: cap-sdk-node@2.17.0 integrity `sha512-4kAPiJeVI7I3ImVX76xElETJvU+PImxarTmcmSkzkMJOvBe61bzfIXhJR6ANRrgJpv9HZq6wYmAr7mMycn3Jew==`.
- pypi.org: cap_sdk_python-2.17.0 whl sha256 5ce86650a5640faa713e..., sdist 8ab83427c9d3a5d9a1df...; cordum_guard-2.17.0 whl 93f4c33432be8166277d..., sdist 32b725143ee0a312d582....
- Clean-environment installed-artifact smokes: empty-GOMODCACHE Go consumer build+run (handshake getter, VerifiedProductionPacket, ValidateResourceRef, NewResourceRegistry callable); fresh npm consumer loadRoot->WorkerHandshakeChallenge/BusPacket + sign/verifyProductionPacket; fresh venv python -I imports of cap.handshake/production_signing/production_resource/worker_trust + cordum_guard.

## Local validation
`cap-release check` OK; `render --check` all in sync; `promotion-check` OK (v2.17.0 -> e580c670 bound); `links` OK; `go build ./...`; `go test ./...` 16 ok / 0 fail.

Context: capstone promotion task task-a24b53c5 (Moe), human-authorized 2026-07-22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the verified published release to **2.17.0**.
  - Updated the supported security release line to **2.17.x**.
  - Updated Go, Node, Python, and Guard SDK support information to **2.17.0**.

- **Development**
  - Advanced SDK package versions to **2.17.1-dev** for ongoing development.

- **Documentation**
  - Refreshed release status, versioning, SDK comparison, support matrices, and wiki details to reflect the 2.17.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->